### PR TITLE
Decouple mail domain

### DIFF
--- a/charts/mediawiki/Chart.yaml
+++ b/charts/mediawiki/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.37"
 description: A Helm wbstack flavoured MediaWiki
 name: mediawiki
-version: 0.7.0
+version: 0.7.1
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/mediawiki/README.md
+++ b/charts/mediawiki/README.md
@@ -2,6 +2,7 @@
 
 ## Changelog
 
+- 0.7.1: Decoupled email domain setting from mailgun values
 - 0.7.0: First 1.37 workin beta image with federated properties v2 (1.37-7.4-20211203-fp-beta-1)
 - 0.6.0: Replaced NodePort with ClusterIP
 - 0.5.2: Fix for `mw.smtp.auth` setting usage in mediawiki

--- a/charts/mediawiki/templates/_helpers.tpl
+++ b/charts/mediawiki/templates/_helpers.tpl
@@ -91,7 +91,7 @@ Common deployment environment variables
 - name: MW_MAILGUN_ENDPOINT
   value: {{ .Values.mw.mailgun.endpoint }}
 - name: MW_EMAIL_DOMAIN
-  value: {{ .Values.mw.mailgun.domain }}
+  value: {{ .Values.mw.mail.domain }}
 - name: MW_RECAPTCHA_SITEKEY
 {{- if .Values.mw.recaptcha.sitekey }}
   value: {{ .Values.mw.recaptcha.sitekey | quote }}

--- a/charts/mediawiki/values.yaml
+++ b/charts/mediawiki/values.yaml
@@ -24,10 +24,11 @@ mw:
   elasticsearch:
     host: someOtherElasticsearchServer
     port: 9200
+  mail:
+    domain: somedomain.name
   mailgun:
     enabled: true
     apikey: 1234567
-    domain: somedomain.name
     endpoint: "https://some.api.endpoint.example"
   smtp:
     enabled: false


### PR DESCRIPTION
This PR cleans up the mw chart a bit by letting you set the domain that is used for mails in a clearer way no matter if you use mailgun or smtp