### PR TITLE
Use `mw.mail.domain` for mailgun

### DIFF
--- a/charts/mediawiki/Chart.yaml
+++ b/charts/mediawiki/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.37"
 description: A Helm wbstack flavoured MediaWiki
 name: mediawiki
-version: 0.7.1
+version: 0.7.2
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/mediawiki/README.md
+++ b/charts/mediawiki/README.md
@@ -2,6 +2,7 @@
 
 ## Changelog
 
+- 0.7.2: Fix for still using `mw.mailgun.domain` in template
 - 0.7.1: Decoupled email domain setting from mailgun values
 - 0.7.0: First 1.37 workin beta image with federated properties v2 (1.37-7.4-20211203-fp-beta-1)
 - 0.6.0: Replaced NodePort with ClusterIP

--- a/charts/mediawiki/templates/_helpers.tpl
+++ b/charts/mediawiki/templates/_helpers.tpl
@@ -87,7 +87,7 @@ Common deployment environment variables
       key: {{ .Values.mw.mailgun.apikeySecretKey | quote }}
 {{- end }}
 - name: MW_MAILGUN_DOMAIN
-  value: {{ .Values.mw.mailgun.domain }}
+  value: {{ .Values.mw.mail.domain }}
 - name: MW_MAILGUN_ENDPOINT
   value: {{ .Values.mw.mailgun.endpoint }}
 - name: MW_EMAIL_DOMAIN


### PR DESCRIPTION
Fix to use the new `mw.mail.domain` setting introduced in https://github.com/wbstack/charts/pull/38 for mailgun