### PR TITLE
Bump MW image to 1.37-7.4-20211217-fp-beta-0

### DIFF
--- a/charts/mediawiki/Chart.yaml
+++ b/charts/mediawiki/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.37"
 description: A Helm wbstack flavoured MediaWiki
 name: mediawiki
-version: 0.7.2
+version: 0.7.3
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/mediawiki/README.md
+++ b/charts/mediawiki/README.md
@@ -2,6 +2,7 @@
 
 ## Changelog
 
+- 0.7.3: Bump MW image to 1.37-7.4-20211217-fp-beta-0 including 1.37.1 security release of MW core
 - 0.7.2: Fix for still using `mw.mailgun.domain` in template
 - 0.7.1: Decoupled email domain setting from mailgun values
 - 0.7.0: First 1.37 workin beta image with federated properties v2 (1.37-7.4-20211203-fp-beta-1)

--- a/charts/mediawiki/values.yaml
+++ b/charts/mediawiki/values.yaml
@@ -6,7 +6,7 @@ replicaCount:
 
 image:
   repository: ghcr.io/wbstack/mediawiki
-  tag: "1.37-7.4-20211203-fp-beta-1"
+  tag: "1.37-7.4-20211217-fp-beta-0"
   pullPolicy: IfNotPresent
 
 mw:


### PR DESCRIPTION
This includes the 1.37.1 security release of MW core