### PR TITLE
UI: Only load recaptcha secret if set

### DIFF
--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "3.0"
 description: A Helm chart for Kubernetes
 name: ui
-version: 0.2.5
+version: 0.2.6
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/ui/templates/deployment.yaml
+++ b/charts/ui/templates/deployment.yaml
@@ -40,11 +40,13 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
+            {{- if .Values.ui.recaptchaSitekeySecretName }}
             - name: RECAPTCHA_SITE_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.ui.recaptchaSitekeySecretName | quote }}
                   key: {{ .Values.ui.recaptchaSitekeySecretKey | quote }}
+            {{- end}}
             - name: API_URL
               value: {{ .Values.ui.apiUrl | quote }}
             - name: SUBDOMAIN_SUFFIX


### PR DESCRIPTION
This is convenient because it means this chart can be deployed in a standalone fashion