### PR TITLE
UI chart v0.2.14 (using release 3.91)

### DIFF
--- a/charts/ui/CHANGELOG.md
+++ b/charts/ui/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This chart does not yet follow SemVer.
 
+## 0.2.14
+- Bumping image to 3.91
+    - update wmde phone numbe
+    - footer imprint link
+
 ## 0.2.13
 - - Bumping image to 3.8 (ToS fix)
 

--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "3.0"
 description: A Helm chart for Kubernetes
 name: ui
-version: 0.2.13
+version: 0.2.14
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/ui/values.yaml
+++ b/charts/ui/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/wbstack/ui
-  tag: "3.8"
+  tag: "3.91"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Uses UI release 3.91 which includes an update to the wmde phone number and a impressum link in the footer
