### PR TITLE
Release mediawiki chart 0.10.2

### DIFF
--- a/charts/mediawiki/Chart.yaml
+++ b/charts/mediawiki/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.37"
 description: A Helm wbstack flavoured MediaWiki
 name: mediawiki
-version: 0.10.1
+version: 0.10.2
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/mediawiki/README.md
+++ b/charts/mediawiki/README.md
@@ -2,6 +2,7 @@
 
 ## Changelog
 
+- 0.10.2: Bump MW image to 1.37-7.4-20220429-fp-beta-0 including search index no pages fix
 - 0.10.1: T301141: Hardcode wikibase concept-uri to HTTPS
 - 0.10.0: Added support for SMTP credentials through secrets
 - 0.9.0: Bump MW image to 1.37-7.4-20220131-fp-beta-0 including no readonly for cli

--- a/charts/mediawiki/values.yaml
+++ b/charts/mediawiki/values.yaml
@@ -6,7 +6,7 @@ replicaCount:
 
 image:
   repository: ghcr.io/wbstack/mediawiki
-  tag: "1.37-7.4-20220304-fp-beta-0"
+  tag: "1.37-7.4-20220429-fp-beta-0"
   pullPolicy: IfNotPresent
 
 mw:


### PR DESCRIPTION
 using 1.37-7.4-20220429-fp-beta-0