### PR TITLE
Bump mw to 0.10.3

### DIFF
--- a/charts/mediawiki/Chart.yaml
+++ b/charts/mediawiki/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.37"
 description: A Helm wbstack flavoured MediaWiki
 name: mediawiki
-version: 0.10.2
+version: 0.10.3
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/mediawiki/README.md
+++ b/charts/mediawiki/README.md
@@ -2,6 +2,7 @@
 
 ## Changelog
 
+- 0.10.3: Bump version number to trigger new chart release
 - 0.10.2: Bump MW image to 1.37-7.4-20220429-fp-beta-0 including search index no pages fix
 - 0.10.1: T301141: Hardcode wikibase concept-uri to HTTPS
 - 0.10.0: Added support for SMTP credentials through secrets


### PR DESCRIPTION
bump mediawiki chart to 0.10.3 to trigger a new chart release