### PR TITLE
Make resource configurable for pod/job + don't keep history forever

### DIFF
--- a/charts/wbaas-backup/CHANGELOG.md
+++ b/charts/wbaas-backup/CHANGELOG.md
@@ -5,7 +5,7 @@ This chart does not yet follow Semantic versioning.
 ## 0.0.4
 
 Adds `ephemeral-storage` request of 60GB by default, limits failed/successful history to 7 runs
-
+Sets request/limit pairs
 ## 0.0.3
 
 Bump image tag to v0.1.6

--- a/charts/wbaas-backup/CHANGELOG.md
+++ b/charts/wbaas-backup/CHANGELOG.md
@@ -6,6 +6,7 @@ This chart does not yet follow Semantic versioning.
 
 Adds `ephemeral-storage` request of 60GB by default, limits failed/successful history to 7 runs
 Sets request/limit pairs
+
 ## 0.0.3
 
 Bump image tag to v0.1.6

--- a/charts/wbaas-backup/CHANGELOG.md
+++ b/charts/wbaas-backup/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This chart does not yet follow Semantic versioning.
 
+## 0.0.4
+
+Adds `ephemeral-storage` request of 60GB by default, limits failed/successful history to 7 runs
+
 ## 0.0.3
 
 Bump image tag to v0.1.6

--- a/charts/wbaas-backup/Chart.yaml
+++ b/charts/wbaas-backup/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for WbaaS K8s Cronjob Backups
 name: wbaas-backup
-version: 0.0.3
+version: 0.0.4
 maintainers:
   - name: WMDE
     url: https://github.com/wmde

--- a/charts/wbaas-backup/templates/_helpers.tpl
+++ b/charts/wbaas-backup/templates/_helpers.tpl
@@ -26,10 +26,6 @@ lifecycle:
     exec:
       command: ["fusermount", "-u", /mnt/backup-bucket"]
 {{- end }}
-resources:
-  limits:
-    cpu: 750m
-    memory: 500Mi
 securityContext:
   privileged: true
   capabilities:

--- a/charts/wbaas-backup/templates/job.yaml
+++ b/charts/wbaas-backup/templates/job.yaml
@@ -3,7 +3,9 @@ kind: CronJob
 metadata:
   name: sql-logic-backup
 spec:
-  schedule: {{ .Values.cronSchedule | quote }} 
+  schedule: {{ .Values.cronSchedule | quote }}
+  successfulJobsHistoryLimit: 7
+  failedJobsHistoryLimit: 7
   jobTemplate:
     spec:
       template:
@@ -12,6 +14,8 @@ spec:
           - name: sql-logic-backup
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
+            resources:
+              {{- toYaml .Values.resources.job | nindent 14 }}
 {{ include "backup.sharedPodConfiguration" ( dict "db" .Values.db.dump "context" $ ) | nindent 12 }}
 {{ include "backup.sharedVolumes" ( dict "gcs" .Values.gcs ) | nindent 10 }}
           restartPolicy: Never

--- a/charts/wbaas-backup/templates/restore-pod.yaml
+++ b/charts/wbaas-backup/templates/restore-pod.yaml
@@ -10,6 +10,8 @@ spec:
     imagePullPolicy: {{ .Values.image.pullPolicy }}
     command: [ "/bin/bash", "-c", "--" ]
     args: [ "while true; do sleep 30; done;" ]
+    resources:
+      {{- toYaml .Values.resources.restorePod | nindent 6 }}
 {{ include "backup.sharedPodConfiguration" ( dict "db" .Values.db.load "context" $ ) | nindent 4 }}
 {{ include "backup.sharedVolumes" ( dict "gcs" .Values.gcs ) | nindent 2 }}
   restartPolicy: Never

--- a/charts/wbaas-backup/values.yaml
+++ b/charts/wbaas-backup/values.yaml
@@ -18,12 +18,17 @@ resources:
   job:
     requests:
       ephemeral-storage: 60Gi
+      cpu: 100m
+      memory: 50Mi
     limits:
       cpu: 750m
       memory: 500Mi
   restorePod:
+    requests:
+      cpu: 100m
+      memory: 50Mi
     limits:
-      cpu: 500m
+      cpu: 750m
       memory: 500Mi
 
 db:

--- a/charts/wbaas-backup/values.yaml
+++ b/charts/wbaas-backup/values.yaml
@@ -14,6 +14,18 @@ gcs:
   serviceAccountSecretName: some-gcs-sa
   uploadToBucket: true
 
+resources:
+  job:
+    requests:
+      ephemeral-storage: 60Gi
+    limits:
+      cpu: 750m
+      memory: 500Mi
+  restorePod:
+    limits:
+      cpu: 500m
+      memory: 500Mi
+
 db:
   load:
     passwordSecretName: sql-secrets-passwords


### PR DESCRIPTION
This releases 0.0.4 of wbaas-backup

Fix for https://phabricator.wikimedia.org/T307199, the pods on production are evicted because they don't specify the disk required.

Make resources configurable and request a 60GB disk at startup
Don't keep history forever.