### PR TITLE
Add wbaas-backup scratch-disk volume for job/restore pod

### DIFF
--- a/charts/wbaas-backup/CHANGELOG.md
+++ b/charts/wbaas-backup/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This chart does not yet follow Semantic versioning.
 
+## 0.0.5
+
+Removes `ephemeral-storage` request, adds a temporary volume instead. Re-organizes some value nodes.
+
 ## 0.0.4
 
 Adds `ephemeral-storage` request of 60GB by default, limits failed/successful history to 7 runs

--- a/charts/wbaas-backup/CHANGELOG.md
+++ b/charts/wbaas-backup/CHANGELOG.md
@@ -5,6 +5,7 @@ This chart does not yet follow Semantic versioning.
 ## 0.0.5
 
 Removes `ephemeral-storage` request, adds a temporary volume instead. Re-organizes some value nodes.
+Make history limits configurable.
 
 ## 0.0.4
 

--- a/charts/wbaas-backup/Chart.yaml
+++ b/charts/wbaas-backup/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for WbaaS K8s Cronjob Backups
 name: wbaas-backup
-version: 0.0.4
+version: 0.0.5
 maintainers:
   - name: WMDE
     url: https://github.com/wmde

--- a/charts/wbaas-backup/templates/_helpers.tpl
+++ b/charts/wbaas-backup/templates/_helpers.tpl
@@ -14,14 +14,16 @@ either will be set to use the `db.load` dict or the `db.dump` dict from the valu
 */}}
 
 {{- define "backup.sharedPodConfiguration" -}}
-{{- if .context.Values.gcs.uploadToBucket }}
 volumeMounts:
+  - name: "scratch-volume"
+    mountPath: "/backups/"
+{{- if .context.Values.storage.gcs.uploadToBucket }}
   - name: "service-account-volume"
     mountPath: "/var/run/secret/cloud.google.com"
 lifecycle:
   postStart:
     exec:
-      command: ["gcsfuse", "--key-file", "/var/run/secret/cloud.google.com/key.json", "{{ .context.Values.gcs.bucketName }}", "/mnt/backup-bucket"]
+      command: ["gcsfuse", "--key-file", "/var/run/secret/cloud.google.com/key.json", "{{ .context.Values.storage.gcs.bucketName }}", "/mnt/backup-bucket"]
   preStop:
     exec:
       command: ["fusermount", "-u", /mnt/backup-bucket"]
@@ -46,9 +48,9 @@ env:
 - name: DB_PORT
   value: {{ .db.port | quote }}
 - name: DO_UPLOAD
-  value: {{ if .context.Values.gcs.uploadToBucket }}"1"{{else}}"0"{{end}}
+  value: {{ if .context.Values.storage.gcs.uploadToBucket }}"1"{{else}}"0"{{end}}
 - name: GCS_BUCKET_NAME
-  value: {{ .context.Values.gcs.bucketName | quote }}
+  value: {{ .context.Values.storage.gcs.bucketName | quote }}
 - name: BACKUP_KEY
   valueFrom:
     secretKeyRef:
@@ -62,12 +64,28 @@ env:
 
 Both the restore-pod and the CronJob requires the backup-bucket to be mounted in order for the backups to be persisted.
 This template mounts the `.Values.gcs` of the values file into the template and configures the pod and the job in the same way.
+
+The uid '1234' is defined in the wbaas-backup Dockerfile
+
 */}}
 {{ define "backup.sharedVolumes" }}
-{{- if .gcs.uploadToBucket }}
+securityContext:
+  fsGroup: 1234
 volumes:
+  - name: scratch-volume
+    ephemeral:
+      volumeClaimTemplate:
+        metadata:
+          labels:
+            type: scratch-volume-type
+        spec:
+          accessModes: [ "ReadWriteOnce" ]
+          resources:
+            requests:
+              storage: {{ .storage.scratchDiskSpace | quote }}
+{{- if .storage.gcs.uploadToBucket }}
   - name: "service-account-volume"
     secret:
-      secretName: {{ .gcs.serviceAccountSecretName | quote }}
+      secretName: {{ .storage.gcs.serviceAccountSecretName | quote }}
 {{- end }}
 {{ end }}

--- a/charts/wbaas-backup/templates/_helpers.tpl
+++ b/charts/wbaas-backup/templates/_helpers.tpl
@@ -70,19 +70,12 @@ The uid '1234' is defined in the wbaas-backup Dockerfile
 */}}
 {{ define "backup.sharedVolumes" }}
 securityContext:
-  fsGroup: 1234
+    fsGroup: 1234
 volumes:
   - name: scratch-volume
-    ephemeral:
-      volumeClaimTemplate:
-        metadata:
-          labels:
-            type: scratch-volume-type
-        spec:
-          accessModes: [ "ReadWriteOnce" ]
-          resources:
-            requests:
-              storage: {{ .storage.scratchDiskSpace | quote }}
+    gcePersistentDisk:
+      pdName: {{ .storage.gcs.scratchDiskName | quote }}
+      fsType: ext4
 {{- if .storage.gcs.uploadToBucket }}
   - name: "service-account-volume"
     secret:

--- a/charts/wbaas-backup/templates/_helpers.tpl
+++ b/charts/wbaas-backup/templates/_helpers.tpl
@@ -75,9 +75,6 @@ volumes:
   - name: scratch-volume
     ephemeral:
       volumeClaimTemplate:
-        metadata:
-          labels:
-            type: scratch-volume-type
         spec:
           accessModes: [ "ReadWriteOnce" ]
           resources:

--- a/charts/wbaas-backup/templates/_helpers.tpl
+++ b/charts/wbaas-backup/templates/_helpers.tpl
@@ -70,12 +70,19 @@ The uid '1234' is defined in the wbaas-backup Dockerfile
 */}}
 {{ define "backup.sharedVolumes" }}
 securityContext:
-    fsGroup: 1234
+  fsGroup: 1234
 volumes:
   - name: scratch-volume
-    gcePersistentDisk:
-      pdName: {{ .storage.gcs.scratchDiskName | quote }}
-      fsType: ext4
+    ephemeral:
+      volumeClaimTemplate:
+        metadata:
+          labels:
+            type: scratch-volume-type
+        spec:
+          accessModes: [ "ReadWriteOnce" ]
+          resources:
+            requests:
+              storage: {{ .storage.scratchDiskSpace | quote }}
 {{- if .storage.gcs.uploadToBucket }}
   - name: "service-account-volume"
     secret:

--- a/charts/wbaas-backup/templates/job.yaml
+++ b/charts/wbaas-backup/templates/job.yaml
@@ -3,9 +3,9 @@ kind: CronJob
 metadata:
   name: sql-logic-backup
 spec:
-  schedule: {{ .Values.cronSchedule | quote }}
-  successfulJobsHistoryLimit: 7
-  failedJobsHistoryLimit: 7
+  schedule: {{ .Values.job.cronSchedule | quote }}
+  successfulJobsHistoryLimit: {{ .Values.job.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.job.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
       template:

--- a/charts/wbaas-backup/templates/job.yaml
+++ b/charts/wbaas-backup/templates/job.yaml
@@ -17,6 +17,6 @@ spec:
             resources:
               {{- toYaml .Values.resources.job | nindent 14 }}
 {{ include "backup.sharedPodConfiguration" ( dict "db" .Values.db.dump "context" $ ) | nindent 12 }}
-{{ include "backup.sharedVolumes" ( dict "gcs" .Values.gcs ) | nindent 10 }}
+{{ include "backup.sharedVolumes" ( dict "storage" .Values.storage ) | nindent 10 }}
           restartPolicy: Never
       backoffLimit: 4

--- a/charts/wbaas-backup/templates/restore-pod.yaml
+++ b/charts/wbaas-backup/templates/restore-pod.yaml
@@ -13,7 +13,7 @@ spec:
     resources:
       {{- toYaml .Values.resources.restorePod | nindent 6 }}
 {{ include "backup.sharedPodConfiguration" ( dict "db" .Values.db.load "context" $ ) | nindent 4 }}
-{{ include "backup.sharedVolumes" ( dict "gcs" .Values.gcs ) | nindent 2 }}
+{{ include "backup.sharedVolumes" ( dict "storage" .Values.storage ) | nindent 2 }}
   restartPolicy: Never
 
 {{- end }}

--- a/charts/wbaas-backup/values.yaml
+++ b/charts/wbaas-backup/values.yaml
@@ -4,7 +4,11 @@ image:
   pullPolicy: IfNotPresent
 
 restorePodRunning: false
-cronSchedule: "0 0 * * *"
+
+job:
+  failedJobsHistoryLimit: 2
+  successfulJobsHistoryLimit: 2
+  cronSchedule: "0 0 * * *"
 
 backupSecretKey: key
 backupSecretName: backup-openssl-key

--- a/charts/wbaas-backup/values.yaml
+++ b/charts/wbaas-backup/values.yaml
@@ -9,15 +9,16 @@ cronSchedule: "0 0 * * *"
 backupSecretKey: key
 backupSecretName: backup-openssl-key
 
-gcs:
-  bucketName: nacho-cheese
-  serviceAccountSecretName: some-gcs-sa
-  uploadToBucket: true
+storage:
+  scratchDiskSpace: 16Gi
+  gcs:
+    bucketName: nacho-cheese
+    serviceAccountSecretName: some-gcs-sa
+    uploadToBucket: true
 
 resources:
   job:
     requests:
-      ephemeral-storage: 60Gi
       cpu: 100m
       memory: 50Mi
     limits:

--- a/charts/wbaas-backup/values.yaml
+++ b/charts/wbaas-backup/values.yaml
@@ -10,8 +10,8 @@ backupSecretKey: key
 backupSecretName: backup-openssl-key
 
 storage:
+  scratchDiskSpace: 16Gi
   gcs:
-    scratchDiskName: logic-backup-scratch-disk
     bucketName: nacho-cheese
     serviceAccountSecretName: some-gcs-sa
     uploadToBucket: true

--- a/charts/wbaas-backup/values.yaml
+++ b/charts/wbaas-backup/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/wmde/wbaas-backup
-  tag: v0.1.6
+  tag: v0.1.7
   pullPolicy: IfNotPresent
 
 restorePodRunning: false

--- a/charts/wbaas-backup/values.yaml
+++ b/charts/wbaas-backup/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/wmde/wbaas-backup
-  tag: v0.1.7
+  tag: v0.1.6
   pullPolicy: IfNotPresent
 
 restorePodRunning: false

--- a/charts/wbaas-backup/values.yaml
+++ b/charts/wbaas-backup/values.yaml
@@ -23,14 +23,14 @@ storage:
 resources:
   job:
     requests:
-      cpu: 100m
+      cpu: 10m
       memory: 50Mi
     limits:
       cpu: 750m
       memory: 500Mi
   restorePod:
     requests:
-      cpu: 100m
+      cpu: 10m
       memory: 50Mi
     limits:
       cpu: 750m

--- a/charts/wbaas-backup/values.yaml
+++ b/charts/wbaas-backup/values.yaml
@@ -10,8 +10,8 @@ backupSecretKey: key
 backupSecretName: backup-openssl-key
 
 storage:
-  scratchDiskSpace: 16Gi
   gcs:
+    scratchDiskName: logic-backup-scratch-disk
     bucketName: nacho-cheese
     serviceAccountSecretName: some-gcs-sa
     uploadToBucket: true


### PR DESCRIPTION
- adds a temp volume for making backups on
- this reshuffles some `gcs` values under `storage`
- makes history limits configurable by moving cronjob and history parameters under job yaml node