### PR TITLE
Release UI chart v0.2.17

### DIFF
--- a/charts/ui/CHANGELOG.md
+++ b/charts/ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This chart does not yet follow SemVer.
 
+## 0.2.17
+- Bumping image to 3.93 (Adds subdomain naming hint)
+
 ## 0.2.16
 - Bumping image to 3.92 (Removes feddy props feedback CTA)
 

--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "3.0"
 description: A Helm chart for Kubernetes
 name: ui
-version: 0.2.16
+version: 0.2.17
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/ui/values.yaml
+++ b/charts/ui/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/wbstack/ui
-  tag: "3.92"
+  tag: "3.93"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Bumps ui image version to 3.93, which includes https://github.com/wbstack/ui/pull/435
https://phabricator.wikimedia.org/T306868