### PR TITLE
Mediawiki: release 0.10.5

### DIFF
--- a/charts/mediawiki/Chart.yaml
+++ b/charts/mediawiki/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.37"
 description: A Helm wbstack flavoured MediaWiki
 name: mediawiki
-version: 0.10.4
+version: 0.10.5
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/mediawiki/README.md
+++ b/charts/mediawiki/README.md
@@ -2,6 +2,7 @@
 
 ## Changelog
 
+- 0.10.5: New MW release with updated CirrusSearch sharding config, we missed one index.
 - 0.10.4: New MW release with CirrusSearch sharding config
 - 0.10.3: Bump version number to trigger new chart release
 - 0.10.2: Bump MW image to 1.37-7.4-20220429-fp-beta-0 including search index no pages fix

--- a/charts/mediawiki/values.yaml
+++ b/charts/mediawiki/values.yaml
@@ -6,7 +6,7 @@ replicaCount:
 
 image:
   repository: ghcr.io/wbstack/mediawiki
-  tag: "1.37-7.4-20220512-fp-beta-0"
+  tag: "1.37-7.4-20220513-fp-beta-0"
   pullPolicy: IfNotPresent
 
 mw:


### PR DESCRIPTION
Updated cirrussearch sharding config, use new image.