### PR TITLE
mediawiki 0.10.6

### DIFF
--- a/charts/mediawiki/Chart.yaml
+++ b/charts/mediawiki/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.37"
 description: A Helm wbstack flavoured MediaWiki
 name: mediawiki
-version: 0.10.5
+version: 0.10.6
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/mediawiki/README.md
+++ b/charts/mediawiki/README.md
@@ -2,6 +2,7 @@
 
 ## Changelog
 
+- 0.10.6: Added `mw.settings.allowedProxyCidr` to set $wgCdnServersNoPurge
 - 0.10.5: New MW release with updated CirrusSearch sharding config, we missed one index.
 - 0.10.4: New MW release with CirrusSearch sharding config
 - 0.10.3: Bump version number to trigger new chart release

--- a/charts/mediawiki/README.md
+++ b/charts/mediawiki/README.md
@@ -1,5 +1,14 @@
 # wbstack mediawiki
 
+## Settings
+### mw.settings.allowedProxyCidr 
+Sets `$wgCdnServersNoPurge` in mediawiki.
+
+In order to see which IP ranges is used for a GKE cluster you can run the following command:
+```
+kubectl get ds kube-proxy -n kube-system -o=jsonpath="{.spec.template.spec.containers[0].command}" | grep -Po '\-\-cluster\-cidr=[^ ]*' | cut -d'=' -f2 | tr -d '"]'
+```
+
 ## Changelog
 
 - 0.10.6: Added `mw.settings.allowedProxyCidr` to set $wgCdnServersNoPurge

--- a/charts/mediawiki/templates/_helpers.tpl
+++ b/charts/mediawiki/templates/_helpers.tpl
@@ -157,6 +157,9 @@ Common deployment environment variables
 
 {{- end -}}
 
+- name: MW_ALLOWED_PROXY_CIDR
+  value: {{ .Values.mw.settings.allowedProxyCidr }}
+
 {{- end -}}
 
 {{/*

--- a/charts/mediawiki/templates/_helpers.tpl
+++ b/charts/mediawiki/templates/_helpers.tpl
@@ -157,8 +157,10 @@ Common deployment environment variables
 
 {{- end -}}
 
+{{- if .Values.mw.smtp.smtpPasswordSecretName }}
 - name: MW_ALLOWED_PROXY_CIDR
-  value: {{ .Values.mw.settings.allowedProxyCidr }}
+  value: {{ .Values.mw.settings.allowedProxyCidr | quote }}
+{{- end -}}
 
 {{- end -}}
 

--- a/charts/mediawiki/templates/_helpers.tpl
+++ b/charts/mediawiki/templates/_helpers.tpl
@@ -157,7 +157,7 @@ Common deployment environment variables
 
 {{- end -}}
 
-{{- if .Values.mw.smtp.smtpPasswordSecretName }}
+{{- if .Values.mw.settings.allowedProxyCidr }}
 - name: MW_ALLOWED_PROXY_CIDR
   value: {{ .Values.mw.settings.allowedProxyCidr | quote }}
 {{- end -}}

--- a/charts/mediawiki/values.yaml
+++ b/charts/mediawiki/values.yaml
@@ -6,7 +6,7 @@ replicaCount:
 
 image:
   repository: ghcr.io/wbstack/mediawiki
-  tag: "1.37-7.4-20220513-fp-beta-0"
+  tag: "1.37-7.4-20220513-fp-beta-0" # TODO change this to new mw release!
   pullPolicy: IfNotPresent
 
 mw:

--- a/charts/mediawiki/values.yaml
+++ b/charts/mediawiki/values.yaml
@@ -12,6 +12,7 @@ image:
 mw:
   settings:
     logToStdErr: false
+    allowedProxyCidr: ""
   db:
     master: someHostName
     replica: someHostName

--- a/charts/mediawiki/values.yaml
+++ b/charts/mediawiki/values.yaml
@@ -6,7 +6,7 @@ replicaCount:
 
 image:
   repository: ghcr.io/wbstack/mediawiki
-  tag: "1.37-7.4-20220513-fp-beta-0" # TODO change this to new mw release!
+  tag: "1.37-7.4-20220621-fp-beta-0"
   pullPolicy: IfNotPresent
 
 mw:


### PR DESCRIPTION
This chart introduces a new environment variable for the mediawiki image set by `mw.settings.allowedProxyCidr` (corresponds to mw setting `$wgCdnServersNoPurge`)

https://phabricator.wikimedia.org/T309687

DRAFT until new mw image is released and tag inserted here in [charts/mediawiki/values.yaml](https://github.com/wbstack/charts/compare/mw-0.10.6?expand=1#diff-80687b9c2db2a16078e80f8f9a1ec46837706c292de4f6b38689036723e5ed44)

https://github.com/wbstack/mediawiki/pull/262