### PR TITLE
api: improve healthchecks

### DIFF
--- a/charts/api/CHANGELOG.md
+++ b/charts/api/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This chart does not yet follow SemVer.
 
+## 0.19.13
+- Increase api healthchecks timeout. Make enable/delay/time/period configurable.
+
 ## 0.19.12
 - Bump fakerphp/faker from 0.18.0 to 0.19.0
 

--- a/charts/api/Chart.yaml
+++ b/charts/api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the WBStack API
 name: api
-version: 0.19.12
+version: 0.19.13
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/api/templates/deployment-app-web.yaml
+++ b/charts/api/templates/deployment-app-web.yaml
@@ -31,14 +31,28 @@ spec:
               containerPort: 80
               protocol: TCP
           {{ if .Values.useProbes }}
+          {{- if .Values.probes.web.livenessProbe.enabled  }}
           livenessProbe:
             httpGet:
               path: /healthz
               port: http
-          readinessProbe:
+            initialDelaySeconds: {{ .Values.probes.web.livenessProbe.initialDelaySeconds }}
+            successThreshold: 1
+            failureThreshold: 3
+            timeoutSeconds: {{ .Values.probes.web.livenessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.probes.web.livenessProbe.periodSeconds }}
+          {{ end }}
+          {{- if .Values.probes.web.readinessProbe.enabled  }}
+          readinessProbe: # TODO Write some new endpoint that checks db etc.
             httpGet:
               path: /healthz
               port: http
+            initialDelaySeconds: {{ .Values.probes.web.readinessProbe.initialDelaySeconds }}
+            successThreshold: 1
+            failureThreshold: 3
+            timeoutSeconds: {{ .Values.probes.web.readinessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.probes.web.readinessProbe.periodSeconds }}
+          {{ end }}
           {{ end }}
           resources:
             {{- toYaml .Values.resources.web | nindent 12 }}

--- a/charts/api/values.yaml
+++ b/charts/api/values.yaml
@@ -4,6 +4,18 @@ image:
   pullPolicy: IfNotPresent
 
 useProbes: true
+probes:
+  web:
+    livenessProbe:
+      enabled: true
+      timeoutSeconds: 2
+      periodSeconds: 10
+      initialDelaySeconds: 10
+    readinessProbe:
+      enabled: true
+      timeoutSeconds: 2
+      periodSeconds: 10
+      initialDelaySeconds: 10
 
 replicaCount:
   web: 1


### PR DESCRIPTION
These have been failing since we launched, just increasing timeout by
one second will reduce these failing.

Bug: T310333