### PR TITLE
api: increase backend pod timeout

### DIFF
--- a/charts/api/CHANGELOG.md
+++ b/charts/api/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 This chart does not yet follow SemVer.
 
+## 0.19.14
+- Increase api-backend healthchecks timeout. Make enable/delay/time/period configurable.
 ## 0.19.13
-- Increase api healthchecks timeout. Make enable/delay/time/period configurable.
+- Increase api-web healthchecks timeout. Make enable/delay/time/period configurable.
 
 ## 0.19.12
 - Bump fakerphp/faker from 0.18.0 to 0.19.0

--- a/charts/api/Chart.yaml
+++ b/charts/api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the WBStack API
 name: api
-version: 0.19.13
+version: 0.19.14
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/api/templates/deployment-app-backend.yaml
+++ b/charts/api/templates/deployment-app-backend.yaml
@@ -30,14 +30,30 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+          {{ if .Values.useProbes }}
+          {{- if .Values.probes.backend.livenessProbe.enabled  }}
           livenessProbe:
             httpGet:
               path: /backend/healthz
               port: http
-          readinessProbe:
+            initialDelaySeconds: {{ .Values.probes.backend.livenessProbe.initialDelaySeconds }}
+            successThreshold: 1
+            failureThreshold: 3
+            timeoutSeconds: {{ .Values.probes.backend.livenessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.probes.backend.livenessProbe.periodSeconds }}
+          {{ end }}
+          {{- if .Values.probes.backend.readinessProbe.enabled  }}
+          readinessProbe: # TODO Write some new endpoint that checks db etc.
             httpGet:
               path: /backend/healthz
               port: http
+            initialDelaySeconds: {{ .Values.probes.backend.readinessProbe.initialDelaySeconds }}
+            successThreshold: 1
+            failureThreshold: 3
+            timeoutSeconds: {{ .Values.probes.backend.readinessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.probes.backend.readinessProbe.periodSeconds }}
+          {{ end }}
+          {{ end }}
           resources:
             {{- toYaml .Values.resources.backend | nindent 12 }}
           env:

--- a/charts/api/values.yaml
+++ b/charts/api/values.yaml
@@ -16,6 +16,17 @@ probes:
       timeoutSeconds: 2
       periodSeconds: 10
       initialDelaySeconds: 10
+  backend:
+    livenessProbe:
+      enabled: true
+      timeoutSeconds: 2
+      periodSeconds: 10
+      initialDelaySeconds: 10
+    readinessProbe:
+      enabled: true
+      timeoutSeconds: 2
+      periodSeconds: 10
+      initialDelaySeconds: 10
 
 replicaCount:
   web: 1


### PR DESCRIPTION
make time parameters configurable.

Didn't realize the backend pod had these default probes too.