### PR TITLE
UI v0.3.0: switch to ingress API version to GA v1 from v1beta1

### DIFF
--- a/charts/ui/CHANGELOG.md
+++ b/charts/ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This chart does not yet follow SemVer.
 
+## 0.2.19
+- Switch to ingress API version to GA v1 from v1beta1
+
 ## 0.2.18
 - Bumping image to 3.94 (Implements landing page v1.0)
 

--- a/charts/ui/CHANGELOG.md
+++ b/charts/ui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This chart does not yet follow SemVer.
 
-## 0.2.19
+## 0.3.0
 - Switch to ingress API version to GA v1 from v1beta1
 
 ## 0.2.18

--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "3.0"
 description: A Helm chart for Kubernetes
 name: ui
-version: 0.2.18
+version: 0.2.19
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "3.0"
 description: A Helm chart for Kubernetes
 name: ui
-version: 0.2.19
+version: 0.3.0
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/ui/templates/ingress.yaml
+++ b/charts/ui/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "ui.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -28,9 +28,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
         {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
https://phabricator.wikimedia.org/T311205

ui chart v0.2.19 uses ingress GA API v1 (instead of v1beta1)

some reconfiguration was neccessary:
- `serviceName` and `servicePort` were merged into a `service` map
- `pathType: Prefix` was added. It seems this wasn't specified earlier which probably falled back to `ImplementationSpecific`, but this is [disencouraged](https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/#what-to-do). It looks like it doesn't really matter if we use `Prefix` or `Exact`, but the former seems more flexible so I chose that.



Testable on local cluster 