### PR TITLE
queryservice v0.2.0: switch to ingress API version to GA v1 from v1beta1

### DIFF
--- a/charts/queryservice/Chart.yaml
+++ b/charts/queryservice/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: queryservice
-version: 0.1.3
+version: 0.2.0
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/queryservice/README.md
+++ b/charts/queryservice/README.md
@@ -2,6 +2,7 @@
 
 ## Changelog
 
+- 0.2.0: Switch to ingress API version to GA v1 from v1beta1
 - 0.1.3: Change service from `NodePort` to `ClusterIP`
 - 0.1.2: Change image pullPolicy values to `IfNotPresent`
 - 0.1.1: Added `useProbes` value (Backwards compatible default to true)

--- a/charts/queryservice/templates/ingress.yaml
+++ b/charts/queryservice/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "wdqs.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -28,9 +28,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            PathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
         {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
same procedure as in #104
