### PR TITLE
API Chart v0.20.1

### DIFF
--- a/charts/api/CHANGELOG.md
+++ b/charts/api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This chart does not yet follow SemVer.
 
+## 0.20.1
+- Add support for env vars `WBSTACK_CONTACT_MAIL_RECIPIENT` and `WBSTACK_CONTACT_MAIL_SENDER`
+- Bump api image to `8x.9.11`
+
 ## 0.20.0
 - Switch to ingress API version to GA v1 from v1beta1
 

--- a/charts/api/Chart.yaml
+++ b/charts/api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the WBStack API
 name: api
-version: 0.20.0
+version: 0.20.1
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/api/templates/_helpers.tpl
+++ b/charts/api/templates/_helpers.tpl
@@ -64,13 +64,13 @@ Common lists of environment variables
 - name: WBSTACK_SUMMARY_INACTIVE_THRESHOLD
   value: {{ .Values.wbstack.summaryInactiveThreshold | quote }}
 {{- end }}
-{{- if .Values.app.contact.mail.recipient }}
+{{- if .Values.wbstack.contact.mail.recipient }}
 - name: WBSTACK_CONTACT_MAIL_RECIPIENT
-  value: {{ .Values.app.contact.mail.recipient | quote }}
+  value: {{ .Values.wbstack.contact.mail.recipient | quote }}
 {{- end }}
-{{- if .Values.app.contact.mail.sender }}
+{{- if .Values.wbstack.contact.mail.sender }}
 - name: WBSTACK_CONTACT_MAIL_SENDER
-  value: {{ .Values.app.contact.mail.sender | quote }}
+  value: {{ .Values.wbstack.contact.mail.sender | quote }}
 {{- end }}
 {{- end -}}
 

--- a/charts/api/templates/_helpers.tpl
+++ b/charts/api/templates/_helpers.tpl
@@ -64,6 +64,14 @@ Common lists of environment variables
 - name: WBSTACK_SUMMARY_INACTIVE_THRESHOLD
   value: {{ .Values.wbstack.summaryInactiveThreshold | quote }}
 {{- end }}
+{{- if .Values.app.contact.mail.recipient }}
+- name: WBSTACK_CONTACT_MAIL_RECIPIENT
+  value: {{ .Values.app.contact.mail.recipient | quote }}
+{{- end }}
+{{- if .Values.app.contact.mail.sender }}
+- name: WBSTACK_CONTACT_MAIL_SENDER
+  value: {{ .Values.app.contact.mail.sender | quote }}
+{{- end }}
 {{- end -}}
 
 {{- define "api.smtpEnvVars" -}}

--- a/charts/api/values.yaml
+++ b/charts/api/values.yaml
@@ -53,6 +53,10 @@ wbstack:
   uiurl:
   wikiDbProvisionVersion:
   wikiDbUseVersion:
+  contact:
+    mail:
+      recipient: someone@wikimedia.de
+      sender: contact-<subject>@wikibase.cloud
 
 app:
   name:
@@ -61,10 +65,6 @@ app:
   keySecretName: someSecretName
   keySecretKey: someSecretKey
   debug: false
-  contact:
-    mail:
-      recipient: someone@wikimedia.de
-      sender: contact-<subject>@wikibase.cloud
   url: https://api.wbstack.com
   timezone: UTC
   cacheDriver: redis

--- a/charts/api/values.yaml
+++ b/charts/api/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/wbstack/api
-  tag: 8x.9.3
+  tag: 8x.9.10
   pullPolicy: IfNotPresent
 
 useProbes: true
@@ -61,6 +61,10 @@ app:
   keySecretName: someSecretName
   keySecretKey: someSecretKey
   debug: false
+  contact:
+    mail:
+      recipient: someone@wikimedia.de
+      sender: contact-<subject>@wikibase.cloud
   url: https://api.wbstack.com
   timezone: UTC
   cacheDriver: redis

--- a/charts/api/values.yaml
+++ b/charts/api/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/wbstack/api
-  tag: 8x.9.10
+  tag: 8x.9.11
   pullPolicy: IfNotPresent
 
 useProbes: true


### PR DESCRIPTION
uses api release 8x.9.11, with the new contact message endpoint and env vars

Depends on: https://github.com/wbstack/api/pull/555

