### PR TITLE
API Chart 0.20.2

### DIFF
--- a/charts/api/CHANGELOG.md
+++ b/charts/api/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This chart does not yet follow SemVer.
 
+## 0.20.2
+- Add support for env var `WBSTACK_ELASTICSEARCH_ENABLED_BY_DEFAULT`
+
 ## 0.20.1
 - Add support for env vars `WBSTACK_CONTACT_MAIL_RECIPIENT` and `WBSTACK_CONTACT_MAIL_SENDER`
 - Bump api image to `8x.9.11`

--- a/charts/api/Chart.yaml
+++ b/charts/api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the WBStack API
 name: api
-version: 0.20.1
+version: 0.20.2
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/api/templates/_helpers.tpl
+++ b/charts/api/templates/_helpers.tpl
@@ -72,6 +72,10 @@ Common lists of environment variables
 - name: WBSTACK_CONTACT_MAIL_SENDER
   value: {{ .Values.wbstack.contact.mail.sender | quote }}
 {{- end }}
+{{- if .Values.wbstack.elasticSearch.enabledForNewWikis }}
+- name: WBSTACK_ELASTICSEARCH_ENABLED_BY_DEFAULT
+  value: {{ .Values.wbstack.elasticSearch.enabledForNewWikis | quote }}
+{{- end }}
 {{- end -}}
 
 {{- define "api.smtpEnvVars" -}}

--- a/charts/api/templates/_helpers.tpl
+++ b/charts/api/templates/_helpers.tpl
@@ -72,9 +72,9 @@ Common lists of environment variables
 - name: WBSTACK_CONTACT_MAIL_SENDER
   value: {{ .Values.wbstack.contact.mail.sender | quote }}
 {{- end }}
-{{- if .Values.wbstack.elasticSearch.enabledForNewWikis }}
+{{- if .Values.wbstack.elasticSearch.enabledByDefault }}
 - name: WBSTACK_ELASTICSEARCH_ENABLED_BY_DEFAULT
-  value: {{ .Values.wbstack.elasticSearch.enabledForNewWikis | quote }}
+  value: {{ .Values.wbstack.elasticSearch.enabledByDefault | quote }}
 {{- end }}
 {{- end -}}
 

--- a/charts/api/values.yaml
+++ b/charts/api/values.yaml
@@ -53,6 +53,8 @@ wbstack:
   uiurl:
   wikiDbProvisionVersion:
   wikiDbUseVersion:
+  elasticSearch:
+    enabledForNewWikis: false
   contact:
     mail:
       recipient: someone@wikimedia.de

--- a/charts/api/values.yaml
+++ b/charts/api/values.yaml
@@ -54,7 +54,7 @@ wbstack:
   wikiDbProvisionVersion:
   wikiDbUseVersion:
   elasticSearch:
-    enabledForNewWikis: false
+    enabledByDefault: false
   contact:
     mail:
       recipient: someone@wikimedia.de


### PR DESCRIPTION
https://phabricator.wikimedia.org/T329551

API chart v0.20.2

Adds the option `wbstack.elasticSearch.enabledForNewWikis` to set the env var `WBSTACK_ELASTICSEARCH_ENABLED_BY_DEFAULT`


