### PR TITLE
feat(ui): allow setting additional labels on pods

### DIFF
--- a/charts/ui/CHANGELOG.md
+++ b/charts/ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This chart does not yet follow SemVer.
 
+## 0.3.1
+- Allow setting additional labels on Deployment Pods
+
 ## 0.3.0
 - Switch to ingress API version to GA v1 from v1beta1
 

--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "3.0"
 description: A Helm chart for Kubernetes
 name: ui
-version: 0.3.0
+version: 0.3.1
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/ui/templates/deployment.yaml
+++ b/charts/ui/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "ui.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/ui/values.yaml
+++ b/charts/ui/values.yaml
@@ -29,3 +29,5 @@ resources: {}
 nodeSelector: {}
 
 tolerations: []
+
+podLabels: {}


### PR DESCRIPTION
Ticket: https://phabricator.wikimedia.org/T330863

If we want to use `ui` as a canary for the Istio rollout, we'll need to be able to pass extra labels.