### PR TITLE
fix(mediawiki): version label cannot be derived from chart metadata, use image tag instead

### DIFF
--- a/charts/mediawiki/Chart.yaml
+++ b/charts/mediawiki/Chart.yaml
@@ -1,8 +1,7 @@
 apiVersion: v1
-appVersion: "1.37"
 description: A Helm wbstack flavoured MediaWiki
 name: mediawiki
-version: 0.10.6
+version: 0.10.7
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/mediawiki/README.md
+++ b/charts/mediawiki/README.md
@@ -11,6 +11,7 @@ kubectl get ds kube-proxy -n kube-system -o=jsonpath="{.spec.template.spec.conta
 
 ## Changelog
 
+- 0.10.7: Set `app.kubernetes.io/version` label based on image tag instead of Chart metadata
 - 0.10.6: Added `mw.settings.allowedProxyCidr` to set $wgCdnServersNoPurge
 - 0.10.5: New MW release with updated CirrusSearch sharding config, we missed one index.
 - 0.10.4: New MW release with CirrusSearch sharding config

--- a/charts/mediawiki/templates/_helpers.tpl
+++ b/charts/mediawiki/templates/_helpers.tpl
@@ -38,9 +38,7 @@ Common labels
 app.kubernetes.io/name: {{ include "mediawiki.name" . }}
 helm.sh/chart: {{ include "mediawiki.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+app.kubernetes.io/version: {{ (split "-" .Values.image.tag)._0 | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 

--- a/charts/mediawiki/values.yaml
+++ b/charts/mediawiki/values.yaml
@@ -6,7 +6,7 @@ replicaCount:
 
 image:
   repository: ghcr.io/wbstack/mediawiki
-  tag: "1.37-7.4-20220621-fp-beta-0"
+  tag: latest
   pullPolicy: IfNotPresent
 
 mw:


### PR DESCRIPTION
When upgrading MediaWiki to 1.38 I noticed pods would still be labeled as `1.37`:

```
$ kubectl describe deployments.apps mediawiki-138-app-api | grep version                                                                                       production
                        app.kubernetes.io/version=1.37
```

Considering we decided not to cut new charts when only updating image versions in [ADR #4](https://github.com/wmde/wbaas-deploy/blob/a5150d93c61e4952b469a0613f0e845bbb9988f3/doc/adr/0004-no-new-chart-for-image-bumps.md), we cannot really use the Chart's appVersion for deriving the label value anymore. Instead, the version should be taken from the image tag.

Right now, this is only confusing, but in case we ever want to start adding more sophisticated routing rules during an upgrade, having the correct labels on resources should be helpful.