### PR TITLE
feat: allow setting configuration values for signup throttling

### DIFF
--- a/charts/api/Chart.yaml
+++ b/charts/api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the WBStack API
 name: api
-version: 0.22.0
+version: 0.23.0
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/api/templates/_helpers.tpl
+++ b/charts/api/templates/_helpers.tpl
@@ -68,6 +68,14 @@ Common lists of environment variables
 - name: WBSTACK_SUMMARY_CREATION_RATE_RANGES
   value: {{ join "," .Values.wbstack.summaryCreationRateRanges | quote }}
 {{- end }}
+{{- if .Values.wbstack.signupThrottlingLimit }}
+- name: WBSTACK_SIGNUP_THROTTLING_LIMIT
+  value: {{ .Values.wbstack.signupThrottlingLimit | quote }}
+{{- end }}
+{{- if .Values.wbstack.signupThrottlingRange }}
+- name: WBSTACK_SIGNUP_THROTTLING_RANGE
+  value: {{ .Values.wbstack.signupThrottlingRange | quote }}
+{{- end }}
 {{- if .Values.wbstack.contact.mail.recipient }}
 - name: WBSTACK_CONTACT_MAIL_RECIPIENT
   value: {{ .Values.wbstack.contact.mail.recipient | quote }}

--- a/charts/api/values.yaml
+++ b/charts/api/values.yaml
@@ -53,6 +53,8 @@ wbstack:
   # constructor: https://www.php.net/manual/en/dateinterval.construct.php
   # E.g. PT6H (6 hours) or P30D (30 days)
   summaryCreationRateRanges: []
+  signupThrottlingLimit:
+  signupThrottlingRange:
   maxWikisPerUser:
   subdomainSuffix: ".undefined.nohost"
   uiurl:


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T335963

Adds the values introduced in https://github.com/wbstack/api/pull/619 with no defaults set.