### PR TITLE
feat(mediawiki): update elasticsearch configuration to support two clusters in parallel

### DIFF
--- a/charts/mediawiki/Chart.yaml
+++ b/charts/mediawiki/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.37"
 description: A Helm wbstack flavoured MediaWiki
 name: mediawiki
-version: 0.10.6
+version: 0.11.0
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/mediawiki/templates/_helpers.tpl
+++ b/charts/mediawiki/templates/_helpers.tpl
@@ -66,10 +66,20 @@ Common deployment environment variables
       name: {{ .Values.mw.redis.passwordSecretName | quote }}
       key: {{ .Values.mw.redis.passwordSecretKey | quote }}
 {{- end }}
-- name: MW_ELASTICSEARCH_HOST
+- name: MW_DEFAULT_ELASTICSEARCH_HOST
   value: {{ .Values.mw.elasticsearch.host }}
-- name: MW_ELASTICSEARCH_PORT
+- name: MW_DEFAULT_ELASTICSEARCH_PORT
   value: {{ .Values.mw.elasticsearch.port | quote }}
+- name: MW_DEFAULT_ELASTICSEARCH_ES6
+  value: {{ .Values.mw.elasticsearch.es6 | quote }}
+{{- if .Values.mw.writeOnlyElasticsearch }}
+- name: MW_WRITE_ONLY_ELASTICSEARCH_HOST
+  value: {{ .Values.mw.writeOnlyElasticsearch.host | quote }}
+- name: MW_WRITE_ONLY_ELASTICSEARCH_PORT
+  value: {{ .Values.mw.writeOnlyElasticsearch.port | quote }}
+- name: MW_WRITE_ONLY_ELASTICSEARCH_ES5
+  value: {{ .Values.mw.writeOnlyElasticsearch.es6 | quote }}
+{{- end }}
 - name: MW_MAILGUN_DISABLED
 {{- if .Values.mw.mailgun.enabled }}
   value: "no"

--- a/charts/mediawiki/values.yaml
+++ b/charts/mediawiki/values.yaml
@@ -25,6 +25,7 @@ mw:
   elasticsearch:
     host: someOtherElasticsearchServer
     port: 9200
+    es6: false
   mail:
     domain: somedomain.name
   mailgun:

--- a/charts/mediawiki/values.yaml
+++ b/charts/mediawiki/values.yaml
@@ -25,7 +25,7 @@ mw:
   elasticsearch:
     host: someOtherElasticsearchServer
     port: 9200
-    es6: false
+    es6: true
   mail:
     domain: somedomain.name
   mailgun:


### PR DESCRIPTION
Supersedes #115

Applies the changes from https://github.com/wbstack/mediawiki/pull/362 and needs to be used _after_ the MediaWiki changes have been deployed already.