### PR TITLE
fix(mediawiki): use correct value to env var mapping

### DIFF
--- a/charts/mediawiki/Chart.yaml
+++ b/charts/mediawiki/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.37"
 description: A Helm wbstack flavoured MediaWiki
 name: mediawiki
-version: 0.11.0
+version: 0.11.1
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/mediawiki/templates/_helpers.tpl
+++ b/charts/mediawiki/templates/_helpers.tpl
@@ -77,7 +77,7 @@ Common deployment environment variables
   value: {{ .Values.mw.writeOnlyElasticsearch.host | quote }}
 - name: MW_WRITE_ONLY_ELASTICSEARCH_PORT
   value: {{ .Values.mw.writeOnlyElasticsearch.port | quote }}
-- name: MW_WRITE_ONLY_ELASTICSEARCH_ES5
+- name: MW_WRITE_ONLY_ELASTICSEARCH_ES6
   value: {{ .Values.mw.writeOnlyElasticsearch.es6 | quote }}
 {{- end }}
 - name: MW_MAILGUN_DISABLED


### PR DESCRIPTION
Fixes a typo made in #122 