### PR TITLE
api chart v0.26.1: add loglevel

### DIFF
--- a/charts/api/CHANGELOG.md
+++ b/charts/api/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This chart does not yet follow SemVer.
 
+## 0.26.1
+- Add env var `LOG_LEVEL` (default `info`)
+
 ## 0.26.0
 - Refactor Recaptcha values
     - renamed env vars to `RECAPTCHA_V3_*`

--- a/charts/api/Chart.yaml
+++ b/charts/api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the WBStack API
 name: api
-version: 0.26.0
+version: 0.26.1
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/api/templates/deployment-app-backend.yaml
+++ b/charts/api/templates/deployment-app-backend.yaml
@@ -145,6 +145,10 @@ spec:
 
           - name: LOG_CHANNEL
             value: stderr
+          {{- if .Values.app.logLevel }}
+          - name: LOG_LEVEL
+            value: {{ .Values.app.logLevel | quote }}
+          {{- end }}
           - name: STACKDRIVER_ENABLED
             value: {{ .Values.app.stackdriver.enabled | quote }}
           - name: STACKDRIVER_PROJECT_ID

--- a/charts/api/templates/deployment-app-web.yaml
+++ b/charts/api/templates/deployment-app-web.yaml
@@ -158,6 +158,10 @@ spec:
 
           - name: LOG_CHANNEL
             value: stderr
+          {{- if .Values.app.logLevel }}
+          - name: LOG_LEVEL
+            value: {{ .Values.app.logLevel | quote }}
+          {{- end }}
           - name: STACKDRIVER_ENABLED
             value: {{ .Values.app.stackdriver.enabled | quote }}
           - name: STACKDRIVER_PROJECT_ID

--- a/charts/api/templates/deployment-queue.yaml
+++ b/charts/api/templates/deployment-queue.yaml
@@ -132,6 +132,10 @@ spec:
 
           - name: LOG_CHANNEL
             value: stderr
+          {{- if .Values.app.logLevel }}
+          - name: LOG_LEVEL
+            value: {{ .Values.app.logLevel | quote }}
+          {{- end }}
           - name: STACKDRIVER_ENABLED
             value: {{ .Values.app.stackdriver.enabled | quote }}
           - name: STACKDRIVER_PROJECT_ID

--- a/charts/api/templates/deployment-scheduler.yaml
+++ b/charts/api/templates/deployment-scheduler.yaml
@@ -124,6 +124,10 @@ spec:
 
           - name: LOG_CHANNEL
             value: stderr
+          {{- if .Values.app.logLevel }}
+          - name: LOG_LEVEL
+            value: {{ .Values.app.logLevel | quote }}
+          {{- end }}
           - name: STACKDRIVER_ENABLED
             value: {{ .Values.app.stackdriver.enabled | quote }}
           - name: STACKDRIVER_PROJECT_ID

--- a/charts/api/values.yaml
+++ b/charts/api/values.yaml
@@ -73,6 +73,7 @@ wbstack:
 app:
   name:
   env: production
+  logLevel: info
   # referring to a k8s secret key/name which holds the app key
   keySecretName: someSecretName
   keySecretKey: someSecretKey


### PR DESCRIPTION
This build upon #126 and adds configuration of Laravels Log Level. Currently every API deployment runs with loglevel `debug` which makes it basically impossible to add debug logs to our code.
