### PR TITLE
feat(api,mediawiki): source pod ip range from config map

### DIFF
--- a/charts/api/Chart.yaml
+++ b/charts/api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the WBStack API
 name: api
-version: 0.25.0
+version: 0.26.0
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/api/templates/_helpers.tpl
+++ b/charts/api/templates/_helpers.tpl
@@ -88,10 +88,12 @@ Common lists of environment variables
 - name: WBSTACK_ELASTICSEARCH_ENABLED_BY_DEFAULT
   value: {{ .Values.wbstack.elasticSearch.enabledByDefault | quote }}
 {{- end }}
-{{- if .Values.trustedProxy.proxies }}
 - name: TRUSTED_PROXY_PROXIES
-  value: {{ join "," .Values.trustedProxy.proxies | quote }}
-{{- end }}
+  valueFrom:
+    configMapKeyRef:
+      name: cluster
+      key: ipv4_cidr
+      optional: true
 {{- end -}}
 
 {{- define "api.smtpEnvVars" -}}

--- a/charts/api/templates/_helpers.tpl
+++ b/charts/api/templates/_helpers.tpl
@@ -87,13 +87,7 @@ Common lists of environment variables
 {{- if .Values.wbstack.elasticSearch.enabledByDefault }}
 - name: WBSTACK_ELASTICSEARCH_ENABLED_BY_DEFAULT
   value: {{ .Values.wbstack.elasticSearch.enabledByDefault | quote }}
-{{- end }}
-- name: TRUSTED_PROXY_PROXIES
-  valueFrom:
-    configMapKeyRef:
-      name: cluster
-      key: ipv4_cidr
-      optional: true
+{{- end -}}
 {{- end -}}
 
 {{- define "api.smtpEnvVars" -}}

--- a/charts/api/templates/deployment-app-web.yaml
+++ b/charts/api/templates/deployment-app-web.yaml
@@ -235,6 +235,12 @@ spec:
                 name: {{ template "api.fullname" . }}-app-passport-keys
                 {{- end }}
                 key: oauth-private.key
+          - name: TRUSTED_PROXY_PROXIES
+            valueFrom:
+              configMapKeyRef:
+                name: cluster
+                key: ipv4_cidr
+                optional: true
       {{- if .Values.app.gce.serviceAccountSecret }}
           volumeMounts:
             - name: "service-account-wbstack-api"

--- a/charts/mediawiki/Chart.yaml
+++ b/charts/mediawiki/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.37"
 description: A Helm wbstack flavoured MediaWiki
 name: mediawiki
-version: 0.11.1
+version: 0.12.0
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/mediawiki/templates/_helpers.tpl
+++ b/charts/mediawiki/templates/_helpers.tpl
@@ -165,13 +165,13 @@ Common deployment environment variables
       key: {{ .Values.mw.smtp.smtpPasswordSecretKey | quote }}
   {{- end }}
 
-{{- end -}}
-
-{{- if .Values.mw.settings.allowedProxyCidr }}
+{{- end }}
 - name: MW_ALLOWED_PROXY_CIDR
-  value: {{ .Values.mw.settings.allowedProxyCidr | quote }}
-{{- end -}}
-
+  valueFrom:
+    configMapKeyRef:
+      name: cluster
+      key: ipv4_cidr
+      optional: true
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Following up on the comment here https://github.com/wmde/wbaas-deploy/pull/1122#discussion_r1304171326 source the pod IP range from a config map value that can be populated automatically by terraform instead of us having to look it up in the GCP UI.