### PR TITLE
feat(queryservice-updater): allow jvm extra opts to be configurable

### DIFF
--- a/charts/queryservice-updater/Chart.yaml
+++ b/charts/queryservice-updater/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: queryservice-updater
-version: 0.1.2
+version: 0.2.0
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/queryservice-updater/templates/deployment.yaml
+++ b/charts/queryservice-updater/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
               # https://medium.com/adorsys/usecontainersupport-to-the-rescue-e77d6cfea712
               # https://merikan.com/2019/04/jvm-in-a-container/
               # http://www.mastertheboss.com/java/solving-java-lang-outofmemoryerror-metaspace-error/
-              value: "-XshowSettings:vm -XX:+UseContainerSupport -Xms15m -Xmx30m -XX:MetaspaceSize=20m -XX:MaxMetaspaceSize=30m -XX:+ExitOnOutOfMemoryError"
+              value: {{ .Values.app.extraJvmOpts | quote }}
               #value: "-XshowSettings:vm -XX:+UseContainerSupport -XX:MinRAMPercentage=50.0 -XX:MaxRAMPercentage=80.0 -XX:MaxMetaspaceSize=30m -XX:+UseSerialGC -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Dcom.sun.management.jmxremote -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.port=1099 -Dcom.sun.management.jmxremote.rmi.port=1099 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
             - name: GC_LOGS
               value: " "

--- a/charts/queryservice-updater/values.yaml
+++ b/charts/queryservice-updater/values.yaml
@@ -5,6 +5,7 @@ app:
   getBatchesEndpoint: some.service/backend/qs/getBatches
   wikibaseScheme: https
   proxyMap: platform-nginx.default.svc.cluster.local:8080
+  extraJvmOpts: "-XshowSettings:vm -XX:+UseContainerSupport -XX:+ExitOnOutOfMemoryError -Xms15m -Xmx30m -XX:MetaspaceSize=20m -XX:MaxMetaspaceSize=30m"
 
 image:
   repository: ghcr.io/wbstack/queryservice-updater


### PR DESCRIPTION
The queryservice-updater is currently still crashing with

```
Terminating due to java.lang.OutOfMemoryError: Java heap space
```

which means we need to allow increasing these values out-of-chart