### PR TITLE
fix: apply distinct labels for pods on api-queue deployments

### DIFF
--- a/charts/api/CHANGELOG.md
+++ b/charts/api/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 This chart does not yet follow SemVer.
 
-## 0.29.0
+## 0.29.1
+- Fix labels on api-queue pods to match
 
+## 0.29.0
 - Add option to deploy multiple named queue workers
 
 ## 0.26.1

--- a/charts/api/Chart.yaml
+++ b/charts/api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the WBStack API
 name: api
-version: 0.29.0
+version: 0.29.1
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/api/templates/deployment-queue.yaml
+++ b/charts/api/templates/deployment-queue.yaml
@@ -12,13 +12,13 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "api.name" $ }}
       app.kubernetes.io/instance: {{ $.Release.Name }}
-      app.kubernetes.io/component: queue
+      app.kubernetes.io/component: queue-{{ . }}
   template:
     metadata:
       labels:
         app.kubernetes.io/name: {{ include "api.name" $ }}
         app.kubernetes.io/instance: {{ $.Release.Name }}
-        app.kubernetes.io/component: queue
+        app.kubernetes.io/component: queue-{{ . }}
     spec:
       serviceAccountName: {{ include "api.fullname" $ }}-defaultrole
     {{- with $.Values.imagePullSecrets }}


### PR DESCRIPTION
Fixup for #134 

Without this changes `deployments/api-queue-something-new` would select the `default`/first deployment as all pods have the same labels.