### PR TITLE
fix: api-backend requires a service monitor object

### DIFF
--- a/charts/api/Chart.yaml
+++ b/charts/api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the WBStack API
 name: api
-version: 0.31.0
+version: 0.31.1
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/api/templates/backend-service-monitor.yml
+++ b/charts/api/templates/backend-service-monitor.yml
@@ -1,0 +1,21 @@
+{{ if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: platform-api-servicemonitor
+  namespace: monitoring
+  labels:
+    monitoring: platform-api
+    {{- .Values.serviceMonitor.additionalLabels | toYaml | nindent 4 }}
+spec:
+  selector:
+    matchLabels:      
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: app-backend
+  namespaceSelector:
+    any: true
+  endpoints:
+    - interval: 10s
+      path: /metrics
+      port: http
+{{ end }}

--- a/charts/api/templates/deployment-app-backend.yaml
+++ b/charts/api/templates/deployment-app-backend.yaml
@@ -13,12 +13,6 @@ spec:
       app.kubernetes.io/component: app-backend
   template:
     metadata:
-      {{- if .Values.queue.horizon.enabled }}
-      annotations:
-        prometheus.io/scrape: 'true'
-        prometheus.io/path: '/metrics'
-        prometheus.io/port: '80'
-      {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "api.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/api/templates/service-backend.yaml
+++ b/charts/api/templates/service-backend.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: {{ include "api.fullname" . }}-app-backend
   labels:
+    app.kubernetes.io/component: app-backend
 {{ include "api.labels" . | indent 4 }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/api/values.yaml
+++ b/charts/api/values.yaml
@@ -70,6 +70,10 @@ queue:
       passwordSecretName: someSecretName
       passwordSecretKey: password
 
+serviceMonitor:
+  enabled: false
+  additionalLabels: {}
+
 platform:
   backendMwHost: someHost
 


### PR DESCRIPTION
Ticket: https://phabricator.wikimedia.org/T342866

I did not recall that Prometheus Operator does not honor annotations but instead requires "ServiceMonitor" or "PodMonitor" objects.