### PR TITLE
ui 0.4.0 : add helm release annotations

### DIFF
--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "3.0"
 description: A Helm chart for Kubernetes
 name: ui
-version: 0.3.1
+version: 0.4.0
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/ui/templates/_helpers.tpl
+++ b/charts/ui/templates/_helpers.tpl
@@ -48,6 +48,6 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Common annotations
 */}}
 {{- define "ui.annotations" -}}
-meta.helm.sh/release-name: {{ .Release.Name }}
+meta.helm.sh/release-name: {{ include "ui.name" . }}
 meta.helm.sh/release-namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/charts/ui/templates/_helpers.tpl
+++ b/charts/ui/templates/_helpers.tpl
@@ -43,3 +43,11 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Common annotations
+*/}}
+{{- define "ui.annotations" -}}
+meta.helm.sh/release-name: {{ .Release.Name }}
+meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/ui/templates/deployment.yaml
+++ b/charts/ui/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-      {{ include "ui.annotations" . | indent 6 }}
+{{ include "ui.annotations" . | indent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/ui/templates/deployment.yaml
+++ b/charts/ui/templates/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "ui.fullname" . }}
   labels:
 {{ include "ui.labels" . | indent 4 }}
+  annotations:
+{{ include "ui.annotations" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -18,6 +20,8 @@ spec:
         {{- with .Values.podLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+      annotations:
+      {{ include "ui.annotations" . | indent 6 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/ui/templates/ingress.yaml
+++ b/charts/ui/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
 {{ include "ui.labels" . | indent 4 }}
   annotations:
-    {{ include "ui.annotations" . | indent 4 }}
+{{ include "ui.annotations" . | indent 4 }}
     {{- with .Values.ingress.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/ui/templates/ingress.yaml
+++ b/charts/ui/templates/ingress.yaml
@@ -6,10 +6,11 @@ metadata:
   name: {{ $fullName }}
   labels:
 {{ include "ui.labels" . | indent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{ include "ui.annotations" . | indent 4 }}
+    {{- with .Values.ingress.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
 {{- if .Values.ingress.tls }}
   tls:

--- a/charts/ui/templates/service.yaml
+++ b/charts/ui/templates/service.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "ui.fullname" . }}
   labels:
 {{ include "ui.labels" . | indent 4 }}
+  annotations:
+{{ include "ui.annotations" . | indent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
This adds some annotations to the UI resources the chart deploys.

As far as I can these are needed to use skaffold along with argocd