### PR TITLE
Add redirects chart

### DIFF
--- a/charts/redirects/.helmignore
+++ b/charts/redirects/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/redirects/Chart.yaml
+++ b/charts/redirects/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: redirects
+description: Create ingresses for redirecting subdomains elsewhere
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+maintainers:
+  - name: WBstack
+    url: https://github.com/wbstack

--- a/charts/redirects/templates/ingresses.yaml
+++ b/charts/redirects/templates/ingresses.yaml
@@ -1,0 +1,30 @@
+{{- range .Values.redirects }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: redirect-ingress-{{ .host }}
+  annotations:
+    nginx.ingress.kubernetes.io/server-snippet: |
+      return {{ .statusCode }} {{ .toLocation }}$request_uri;  
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: {{ .host | quote }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            # This isn't used, but needs to be specified.
+            name: example1
+            port:
+              number: 80
+  {{ if .tlsName }}
+  tls:
+  - hosts:
+    - {{ .host | quote }}
+    secretName: {{ .tlsName }}-tls
+  {{- end }}
+{{- end }}

--- a/charts/redirects/values.yaml
+++ b/charts/redirects/values.yaml
@@ -1,0 +1,5 @@
+redirects:
+  - host: example.com
+    toLocation: https://example.net
+    statusCode: 302
+    tlsName: tls-example-secret


### PR DESCRIPTION
This moves the redirects chart from the deploy repository to this charts repository.

This allows it to be properly versioned so that its easy to run different versions on staging and production at the same time.

Bug: T374418