### PR TITLE
Bump argocd config

### DIFF
--- a/charts/argocd-config/Chart.yaml
+++ b/charts/argocd-config/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-config
 description: Chart to deploy ArgoCD configuration (including the argocd-apps chart)
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "1.0"
 maintainers:
   - name: WBstack

--- a/charts/argocd-config/templates/app-of-apps.yaml
+++ b/charts/argocd-config/templates/app-of-apps.yaml
@@ -9,8 +9,8 @@ spec:
   project: {{ .Values.environment }}
   source:
     path: charts/argocd-apps
-    repoURL: {{ .Values.repoUrls.deploy }}
-    targetRevision: HEAD
+    repoURL: https://wbstack.github.io/charts
+    targetRevision: 1.0.1
     helm:
       values: |
 {{ toYaml .Values | indent 8 }}


### PR DESCRIPTION
We now use the new version of the `app-of-apps` chart that we moved from `wbaas-deploy` repo.
When we use the new version of this chart in helmfile, this will trigger the new version of the `app-of-apps` chart from the `charts` repo and should be deployed by argo.
However the new version of the app-of-apps shouldn't contain anything different in the application UI configuration and shouldn't change what we deploy.