### PR TITLE
linting: update ct version to v3.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 lint:
-	docker run --rm -it -v $(shell pwd):/repo -w /repo quay.io/helmpack/chart-testing:v2.5.0 ct lint --config ct.yml
+	docker run --rm -it --user $(shell id -u) -v $(shell pwd):/repo -w /repo quay.io/helmpack/chart-testing:v3.4.0 ct lint --config ct.yml
 
 .PHONY: lint

--- a/ct.yml
+++ b/ct.yml
@@ -1,4 +1,3 @@
-helm-extra-args: --timeout 600s
 chart-dirs:
   - charts
 target-branch: main


### PR DESCRIPTION
This is the version used by the github action version currently in use (v2.1.0)

This commit also removes what appears now to be a
deprecated `timeout` flag passed to helm which was causing the updated version to fail to run.

This commit also ensures that the docker user running ct matches the local user rather than running as root and causing git issues.