### PR TITLE
Add repo to chart releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
+      - name: add repos
+        run: |
+          helm repo add istiod https://istio-release.storage.googleapis.com/charts
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.1.0
         env:


### PR DESCRIPTION
Following the instructions in https://github.com/helm/chart-releaser, we need to add the dependency repository in the action flow.