### PR TITLE
argocd-apps: bump to 1.0.3

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-apps
 description: Chart to deploy WBaaS apps in an "app-of-apps" pattern via ArgoCD
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: "1.0"
 maintainers:
   - name: WBstack


### PR DESCRIPTION
workaround version bump due to https://phabricator.wikimedia.org/T307481

