### PR TITLE
argocd-apps: use api chart v0.32.0

### DIFF
--- a/charts/argocd-apps/templates/wbaas-api.yaml
+++ b/charts/argocd-apps/templates/wbaas-api.yaml
@@ -12,7 +12,7 @@ spec:
   project: {{ .Values.environment }}
   sources:
     - repoURL: {{ .Values.repoUrls.wbstack }}
-      targetRevision: 0.31.2
+      targetRevision: 0.32.0
       chart: api
       helm:
         valueFiles:


### PR DESCRIPTION
use the fixed api chart in argocd https://phabricator.wikimedia.org/T375268

