### PR TITLE
argocd-config: add clusterResourceWhitelist

### DIFF
--- a/charts/argocd-config/templates/projects.yaml
+++ b/charts/argocd-config/templates/projects.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   description: The {{ .Values.environment }} deployment of wikibase.cloud
   destinations:
+  - name: in-cluster-monitoring
+    namespace: monitoring
+    server: https://kubernetes.default.svc
   - name: in-cluster-default
     namespace: default
     server: https://kubernetes.default.svc
@@ -15,3 +18,6 @@ spec:
   - {{ .Values.repoUrls.deploy }}
   - {{ .Values.repoUrls.charts }}
   - {{ .Values.repoUrls.wbstack }}
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'


### PR DESCRIPTION
This fixes the permission problem described here https://phabricator.wikimedia.org/T374217#10176648

This allow list is probably overpermissive, but I think it's still better than using the default project, since this makes it explicit. In the futureTM we can decide to investigate how to scope this down in the sense of the principle of least privilege.

