### PR TITLE
attempt to fix lint workflow by using a different python version

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7.1
+          python-version: 3.13.0
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1


### PR DESCRIPTION
this workflow currently always fails, because the python version 3.7 is now missing for some reason

```
Run actions/setup-python@v2
Version 3.7 was not found in the local cache
Error: Version 3.7 with arch x64 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```
