### PR TITLE
argocd: make chart versions configurable + cleanup

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-apps
 description: Chart to deploy WBaaS apps in an "app-of-apps" pattern via ArgoCD
 type: application
-version: 1.0.8
+version: 1.1.0
 appVersion: "1.0"
 maintainers:
   - name: WBstack

--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-apps
 description: Chart to deploy WBaaS apps in an "app-of-apps" pattern via ArgoCD
 type: application
-version: 1.0.7
+version: 1.0.8
 appVersion: "1.0"
 maintainers:
   - name: WBstack

--- a/charts/argocd-apps/README.md
+++ b/charts/argocd-apps/README.md
@@ -3,6 +3,10 @@
 Deploys actual `Application` manifests for Argo CD. This chart gets treated as it's own `Application`, the app-of-apps, by the chart [argocd-config](../argocd-config/README.md).
 
 ## Changelog
+## 1.0.8
+- remove git repo url for wbstack/charts
+- use helm chart notation instead for the ui
+
 ## 1.0.7
 - add redis-2 manifest
 

--- a/charts/argocd-apps/README.md
+++ b/charts/argocd-apps/README.md
@@ -3,12 +3,14 @@
 Deploys actual `Application` manifests for Argo CD. This chart gets treated as it's own `Application`, the app-of-apps, by the chart [argocd-config](../argocd-config/README.md).
 
 ## Changelog
+## 1.0.7
+- add redis-2 manifest
+
 ## 1.0.6
-- use helm chart notation for wbaas-ui
-- remove unused wbstack git repo URL 
+- add redis manifest
 
 ## 1.0.5
-- add redis manifest
+- use wbaas-api chart v0.32.1
 
 ## 1.0.4
 - use wbaas-api chart v0.32.0

--- a/charts/argocd-apps/README.md
+++ b/charts/argocd-apps/README.md
@@ -3,9 +3,10 @@
 Deploys actual `Application` manifests for Argo CD. This chart gets treated as it's own `Application`, the app-of-apps, by the chart [argocd-config](../argocd-config/README.md).
 
 ## Changelog
-## 1.0.8
-- remove git repo url for wbstack/charts
+## 1.1.0
+- move app chart versions to values file
 - use helm chart notation instead for the ui
+- remove git repo url for wbstack/charts
 
 ## 1.0.7
 - add redis-2 manifest

--- a/charts/argocd-apps/README.md
+++ b/charts/argocd-apps/README.md
@@ -1,0 +1,25 @@
+# argocd-apps
+
+Deploys actual `Application` manifests for Argo CD. This chart gets treated as it's own `Application`, the app-of-apps, by the chart [argocd-config](../argocd-config/README.md).
+
+## Changelog
+## 1.0.6
+- use helm chart notation for wbaas-ui
+- remove unused wbstack git repo URL 
+
+## 1.0.5
+- add redis manifest
+
+## 1.0.4
+- use wbaas-api chart v0.32.0
+
+## 1.0.3
+- unspecified version bump
+
+### 1.0.2
+- add wbstack helm charts repo
+- add wbaas-api manifest 
+
+### 1.0.1
+- initial version in this repository
+- includes wbaas-ui manifest

--- a/charts/argocd-apps/templates/wbaas-api.yaml
+++ b/charts/argocd-apps/templates/wbaas-api.yaml
@@ -12,7 +12,7 @@ spec:
   project: {{ .Values.environment }}
   sources:
     - repoURL: {{ .Values.repoUrls.wbstack }}
-      targetRevision: 0.32.1
+      targetRevision: {{ .Values.chartVersions.wbaasApi }}
       chart: api
       helm:
         valueFiles:

--- a/charts/argocd-apps/templates/wbaas-ui.yaml
+++ b/charts/argocd-apps/templates/wbaas-ui.yaml
@@ -12,8 +12,8 @@ spec:
   project: {{ .Values.environment }}
   sources:
     - repoURL: {{ .Values.repoUrls.charts }}
-      path: charts/ui
-      targetRevision: HEAD
+      chart: ui
+      targetRevision: 0.4.0
       helm:
         valueFiles:
           - $values/k8s/argocd/{{ .Values.environment }}/ui.values.yaml

--- a/charts/argocd-apps/templates/wbaas-ui.yaml
+++ b/charts/argocd-apps/templates/wbaas-ui.yaml
@@ -12,14 +12,14 @@ spec:
   project: {{ .Values.environment }}
   sources:
     - repoURL: {{ .Values.repoUrls.charts }}
+      targetRevision: {{ .Values.chartVersions.wbaasUi }}
       chart: ui
-      targetRevision: 0.4.0
       helm:
         valueFiles:
-          - $values/k8s/argocd/{{ .Values.environment }}/ui.values.yaml
+          - $deployRepo/k8s/argocd/{{ .Values.environment }}/ui.values.yaml
     - repoURL: {{ .Values.repoUrls.deploy }}
       targetRevision: HEAD
-      ref: values
+      ref: deployRepo
 
   syncPolicy:
     automated:

--- a/charts/argocd-apps/values.yaml
+++ b/charts/argocd-apps/values.yaml
@@ -6,6 +6,8 @@ clusterUrl: https://kubernetes.default.svc
 environment: production
 
 chartVersions:
+  wbaasUi: 0.4.0
+  wbaasApi: 0.32.1
   redis: 17.3.8
   redis2: 20.3.0
 # "inherits" values from argocd-config chart

--- a/charts/argocd-apps/values.yaml
+++ b/charts/argocd-apps/values.yaml
@@ -1,6 +1,5 @@
 repoUrls:
   deploy: https://github.com/wmde/wbaas-deploy
-  charts: https://github.com/wbstack/charts.git
   wbstack: https://wbstack.github.io/charts
   bitnami: https://charts.bitnami.com/bitnami
 clusterUrl: https://kubernetes.default.svc

--- a/charts/argocd-apps/values.yaml
+++ b/charts/argocd-apps/values.yaml
@@ -9,5 +9,5 @@ chartVersions:
   wbaasUi: 0.4.0
   wbaasApi: 0.32.1
   redis: 17.3.8
-  redis2: 20.3.0
+  redis2: 19.6.4
 # "inherits" values from argocd-config chart

--- a/charts/argocd-config/Chart.yaml
+++ b/charts/argocd-config/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-config
 description: Chart to deploy ArgoCD configuration (including the argocd-apps chart)
 type: application
-version: 1.0.11
+version: 1.1.0
 appVersion: "1.0"
 maintainers:
   - name: WBstack

--- a/charts/argocd-config/Chart.yaml
+++ b/charts/argocd-config/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-config
 description: Chart to deploy ArgoCD configuration (including the argocd-apps chart)
 type: application
-version: 1.0.10
+version: 1.0.11
 appVersion: "1.0"
 maintainers:
   - name: WBstack

--- a/charts/argocd-config/README.md
+++ b/charts/argocd-config/README.md
@@ -3,6 +3,10 @@
 Configures permissions Argo CD and deploys the "app-of-apps" (see ../argocd-apps/README.md)
 
 ## Changelog
+## 1.0.8
+- use app-of-apps chart v1.0.6
+- remove wbstack charts git repo URL
+
 ## 1.0.7
 - use app-of-apps chart v1.0.5
 - add bitnami chart repo URL

--- a/charts/argocd-config/README.md
+++ b/charts/argocd-config/README.md
@@ -3,6 +3,15 @@
 Configures permissions Argo CD and deploys the "app-of-apps" (see ../argocd-apps/README.md)
 
 ## Changelog
+## 1.0.11
+- remove unused git repo URL to wbstack/charts
+
+## 1.0.10
+- use app-of-apps chart v1.0.7
+
+## 1.0.9
+- replace hardcoded app-of-apps repo URL with configurable value
+
 ## 1.0.8
 - use app-of-apps chart v1.0.6
 - remove wbstack charts git repo URL

--- a/charts/argocd-config/README.md
+++ b/charts/argocd-config/README.md
@@ -3,6 +3,9 @@
 Configures permissions Argo CD and deploys the "app-of-apps" (see ../argocd-apps/README.md)
 
 ## Changelog
+## 1.1.0
+- read app-of-apps chart version from wbaas-deploy repo
+
 ## 1.0.11
 - remove unused git repo URL to wbstack/charts
 

--- a/charts/argocd-config/README.md
+++ b/charts/argocd-config/README.md
@@ -1,0 +1,32 @@
+# argocd-config
+
+Configures permissions Argo CD and deploys the "app-of-apps" (see ../argocd-apps/README.md)
+
+## Changelog
+## 1.0.7
+- use app-of-apps chart v1.0.5
+- add bitnami chart repo URL
+
+## 1.0.6
+- use app-of-apps chart v1.0.4
+- add allowed destination `in-cluster-monitoring` (needed for wbaas-api deployment)
+- add `clusterResourceWhitelist` with ClusterRole and ClusterRoleBinding (needed for wbaas-api deployment)
+
+## 1.0.5
+- just a version bump due to chart release concurrency bug https://phabricator.wikimedia.org/T307481
+
+## 1.0.4
+- use app-of-apps chart v1.0.3
+
+## 1.0.3
+- use configurable wbstack chart URL instead of hardcoded string
+
+## 1.0.2
+- specify app-of-apps chart name
+- add wbstack chart url to values file
+
+### 1.0.1
+- use app-of-apps chart 1.0.1
+
+### 1.0.0
+- initial version in this repository

--- a/charts/argocd-config/templates/app-of-apps.yaml
+++ b/charts/argocd-config/templates/app-of-apps.yaml
@@ -9,7 +9,7 @@ spec:
   project: {{ .Values.environment }}
   sources:
     - repoURL: {{ .Values.repoUrls.wbstack }}
-      targetRevision: 1.0.7
+      targetRevision: {{ .Values.appOfAppsVersion }}
       chart: argocd-apps
       helm:
         values: |

--- a/charts/argocd-config/templates/projects.yaml
+++ b/charts/argocd-config/templates/projects.yaml
@@ -24,3 +24,4 @@ spec:
     kind: ClusterRole
   - group: rbac.authorization.k8s.io
     kind: ClusterRoleBinding
+  - {{ .Values.repoUrls.wbstack }}

--- a/charts/argocd-config/templates/projects.yaml
+++ b/charts/argocd-config/templates/projects.yaml
@@ -16,7 +16,6 @@ spec:
     server: https://kubernetes.default.svc
   sourceRepos:
   - {{ .Values.repoUrls.deploy }}
-  - {{ .Values.repoUrls.charts }}
   - {{ .Values.repoUrls.wbstack }}
   - {{ .Values.repoUrls.bitnami }}
   clusterResourceWhitelist:
@@ -24,4 +23,3 @@ spec:
     kind: ClusterRole
   - group: rbac.authorization.k8s.io
     kind: ClusterRoleBinding
-  - {{ .Values.repoUrls.wbstack }}

--- a/charts/argocd-config/values.yaml
+++ b/charts/argocd-config/values.yaml
@@ -2,6 +2,5 @@ environment: production
 
 repoUrls:
   deploy: https://github.com/wmde/wbaas-deploy
-  charts: https://github.com/wbstack/charts.git
   wbstack: https://wbstack.github.io/charts
   bitnami: https://charts.bitnami.com/bitnami

--- a/charts/argocd-config/values.yaml
+++ b/charts/argocd-config/values.yaml
@@ -1,5 +1,7 @@
 environment: production
 
+appOfAppsVersion: 1.1.0
+
 repoUrls:
   deploy: https://github.com/wmde/wbaas-deploy
   wbstack: https://wbstack.github.io/charts


### PR DESCRIPTION
- makes chart versions configurable/reads from wbaas-deploy for apps and app-of-apps
- cleanup: removes the git repo url of our charts repo and uses the helm chart notation instead for the ui.
- adds missing changelogs for these charts.

> [!NOTE]
> should get merged after #171