### PR TITLE
argocd-config: fix app-of-apps repo URL

### DIFF
--- a/charts/argocd-config/Chart.yaml
+++ b/charts/argocd-config/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-config
 description: Chart to deploy ArgoCD configuration (including the argocd-apps chart)
 type: application
-version: 1.0.8
+version: 1.0.9
 appVersion: "1.0"
 maintainers:
   - name: WBstack

--- a/charts/argocd-config/templates/app-of-apps.yaml
+++ b/charts/argocd-config/templates/app-of-apps.yaml
@@ -8,7 +8,7 @@ spec:
     namespace: argocd
   project: {{ .Values.environment }}
   sources:
-    - repoURL: https://github.com/wbstack/charts.git
+    - repoURL: {{ .Values.repoUrls.wbstack }}
       targetRevision: 1.0.6
       chart: argocd-apps
       helm:


### PR DESCRIPTION
1.0.8 mistakenly use the raw .git repo which made it easy to test the unreleased chart.
Instead we should use the properly helm chart repo

Bug: T375195