### PR TITLE
wikibase-cloud-clusterissuers v0.2.0: add local `ClusterIssuer`

### DIFF
--- a/charts/wikibase-cloud-clusterissuers/Chart.yaml
+++ b/charts/wikibase-cloud-clusterissuers/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: wikibase-cloud-clusterissuers
-version: 0.1.0
+version: 0.2.0
 maintainers:
   - name: WBstack
     url: https://github.com/wbstack

--- a/charts/wikibase-cloud-clusterissuers/README.md
+++ b/charts/wikibase-cloud-clusterissuers/README.md
@@ -1,0 +1,9 @@
+# wbstack-cloud-clusterisssuers
+
+This chart deploys cert-manager `ClusterIssuer` resources, which represent CAs that are able to generate signed certificates by honoring certificate signing requests. The `ClusterIssuer` resource is almost identical to the `Issuer` resource, however is non-namespaced so it can be used to issue `Certificates` across all namespaces.
+
+https://cert-manager.io/docs/configuration/
+
+## changelog
+- 0.2.0: Add self-signed cluster issuer for local environment
+- 0.1.0: Initial tag

--- a/charts/wikibase-cloud-clusterissuers/templates/local.yaml
+++ b/charts/wikibase-cloud-clusterissuers/templates/local.yaml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-cluster-issuer
+  namespace: cert-manager
+spec:
+  selfSigned: {}


### PR DESCRIPTION
https://phabricator.wikimedia.org/T378691

This adds a self-signed cert `ClusterIssuer` in order to use TLS in our local environment via cert-manager.

https://cert-manager.io/docs/configuration/


