### PR TITLE
mediawiki: config for second redis cluster

### DIFF
--- a/charts/mediawiki/Chart.yaml
+++ b/charts/mediawiki/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.37"
 description: A Helm wbstack flavoured MediaWiki
 name: mediawiki
-version: 0.12.0
+version: 0.13.0
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/mediawiki/templates/_helpers.tpl
+++ b/charts/mediawiki/templates/_helpers.tpl
@@ -56,6 +56,10 @@ Common deployment environment variables
   value: {{ .Values.mw.redis.readServer }}
 - name: MW_REDIS_SERVER_WRITE
   value: {{ .Values.mw.redis.writeServer }}
+- name: MW_REDIS_CACHE_SERVER_READ
+  value: {{ .Values.mw.redis.readCacheServer }}
+- name: MW_REDIS_CACHE_SERVER_WRITE
+  value: {{ .Values.mw.redis.writeCacheServer }}
 - name: MW_REDIS_PASSWORD
 {{- if .Values.mw.redis.password }}
   value: {{ .Values.mw.redis.password | quote }}

--- a/charts/mediawiki/values.yaml
+++ b/charts/mediawiki/values.yaml
@@ -25,6 +25,8 @@ mw:
   redis:
     readServer: someRedisOtherServer
     writeServer: someRedisServer
+    readCacheServer: aThirdRedisServerForVeryVolatileKeys
+    writeCacheServer: aFourthRedisServerForVeryVolatileKeys
     password: abc123
     # passwordSecretName:
     # passwordSecretKey:


### PR DESCRIPTION
Adds values and environment variables for using second redis cluster. Also bumps default image value to newer one that takes advantage of this new setting

Bug: T380448