### PR TITLE
wikibase-cloud-clusterissuers v0.2.1

### DIFF
--- a/charts/wikibase-cloud-clusterissuers/Chart.yaml
+++ b/charts/wikibase-cloud-clusterissuers/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: wikibase-cloud-clusterissuers
-version: 0.2.0
+version: 0.2.1
 maintainers:
   - name: WBstack
     url: https://github.com/wbstack

--- a/charts/wikibase-cloud-clusterissuers/README.md
+++ b/charts/wikibase-cloud-clusterissuers/README.md
@@ -5,5 +5,6 @@ This chart deploys cert-manager `ClusterIssuer` resources, which represent CAs t
 https://cert-manager.io/docs/configuration/
 
 ## changelog
+- 0.2.1: Add self-signed CA bootstrapping (docs: https://cert-manager.io/docs/configuration/selfsigned/#bootstrapping-ca-issuers)
 - 0.2.0: Add self-signed cluster issuer for local environment
 - 0.1.0: Initial tag

--- a/charts/wikibase-cloud-clusterissuers/templates/local.yaml
+++ b/charts/wikibase-cloud-clusterissuers/templates/local.yaml
@@ -5,3 +5,29 @@ metadata:
   namespace: cert-manager
 spec:
   selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wikibase-local-root-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: wikibase-local-root-ca
+  secretName: wikibase-local-root-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-cluster-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: wikibase-local-issuer
+  namespace: cert-manager
+spec:
+  ca:
+    secretName: wikibase-local-root-secret


### PR DESCRIPTION
This refactors the local certificate handling by usign a pattern to bootstrap a self-signed CA certificate, which then can be imported by developers for convenience.

docs: https://cert-manager.io/docs/configuration/selfsigned/#bootstrapping-ca-issuers

