### PR TITLE
certificates 0.1.1: add namespace value

### DIFF
--- a/charts/certificates/Chart.yaml
+++ b/charts/certificates/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/certificates/README.md
+++ b/charts/certificates/README.md
@@ -1,0 +1,8 @@
+#
+
+## Changelog
+# 0.1.1
+- added `namespace` as a field for a `Certificate`
+
+# 0.1.0
+- initial version

--- a/charts/certificates/templates/certificate.yaml
+++ b/charts/certificates/templates/certificate.yaml
@@ -3,7 +3,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ .name }}
-  namespace: default
+  namespace: {{ .namespace | default "default" }}
 spec:
   commonName: {{ .commonName }}
   dnsNames:

--- a/charts/certificates/values.yaml
+++ b/charts/certificates/values.yaml
@@ -4,6 +4,7 @@ certificates: []
 # certificates:
 #   -
 #     name: wikibase-cloud-tls
+#     namespace: default
 #     commonName: somedomain.com
 #     dnsNames:
 #       - '*.somedomain.com'


### PR DESCRIPTION
This adds the option to define the namespace for the `Certificate`. Empty string defaults to `default`, so this is change is compatible to older configuration.

