### PR TITLE
DNM: proof of concept for self-signed cert volume mount 

### DIFF
--- a/charts/tool-quickstatements/templates/deployment.yaml
+++ b/charts/tool-quickstatements/templates/deployment.yaml
@@ -70,6 +70,15 @@ spec:
           #     port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /etc/ssl/certs/ca-certificates.crt
+              name: ca-certificates
+              subPath: ca.crt
+      volumes:
+        - name: ca-certificates
+          secret:
+            secretName: wikibase-local-tls
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
https://phabricator.wikimedia.org/T383335

This is only a proof of concept I wanted to share how we can use our self-signed CA certificates into a tool deployment by only using a volume mount from the k8s secret. This approach is super hacky as the file it mounts to usually contains all the certificates that live in /etc/ssl/certs. Normally you would add the cert under /usr/share/ca-certificates/ and run `upddate-ca-certificates`, but this would require us to either know the cert at image buildtime or to use something like an k8s operator or something to inject this later.

