### PR TITLE
wikibase-cloud-clusterissuers 0.3.0: deploy conditionally

### DIFF
--- a/charts/wikibase-cloud-clusterissuers/Chart.yaml
+++ b/charts/wikibase-cloud-clusterissuers/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: wikibase-cloud-clusterissuers
-version: 0.2.1
+version: 0.3.0
 maintainers:
   - name: WBstack
     url: https://github.com/wbstack

--- a/charts/wikibase-cloud-clusterissuers/README.md
+++ b/charts/wikibase-cloud-clusterissuers/README.md
@@ -5,6 +5,7 @@ This chart deploys cert-manager `ClusterIssuer` resources, which represent CAs t
 https://cert-manager.io/docs/configuration/
 
 ## changelog
+- 0.3.0: Wrap resource definitions in conditional blocks, to ensure only relevant resources get deployed to the right environment
 - 0.2.1: Add self-signed CA bootstrapping (docs: https://cert-manager.io/docs/configuration/selfsigned/#bootstrapping-ca-issuers)
 - 0.2.0: Add self-signed cluster issuer for local environment
 - 0.1.0: Initial tag

--- a/charts/wikibase-cloud-clusterissuers/templates/local.yaml
+++ b/charts/wikibase-cloud-clusterissuers/templates/local.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.environment "local" }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -31,3 +32,4 @@ metadata:
 spec:
   ca:
     secretName: wikibase-local-root-secret
+{{- end }}

--- a/charts/wikibase-cloud-clusterissuers/templates/production.yaml
+++ b/charts/wikibase-cloud-clusterissuers/templates/production.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.environment "production" }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -34,4 +35,4 @@ spec:
             - {{ . | quote }}
           {{- end }}
         {{- end }}
-
+{{- end }}

--- a/charts/wikibase-cloud-clusterissuers/templates/staging.yaml
+++ b/charts/wikibase-cloud-clusterissuers/templates/staging.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.environment "staging" }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -34,3 +35,4 @@ spec:
               - {{ . | quote }}
             {{- end }}
           {{- end }}
+{{- end }}


### PR DESCRIPTION
https://phabricator.wikimedia.org/T383335#10591561

To ensure only relevant clusterissuer resources end up in the environment which need them, this adds simple conditional clauses around the environment specific resource definitions.
Especially to restrict the self-signed stuff to the local env only, but overall useful to separate all envs.

