### PR TITLE
quickstatements 0.3.0: extra tls chart

### DIFF
--- a/charts/tool-quickstatements/Chart.yaml
+++ b/charts/tool-quickstatements/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: tool-quickstatements
-version: "0.2.3"
+version: "0.3.0"
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/tool-quickstatements/README.md
+++ b/charts/tool-quickstatements/README.md
@@ -1,7 +1,7 @@
 # wbstack tool-quickstatement
 
 ## Changelog
-
+- 0.3.0: Add extra tls cert volume mount
 - 0.2.3: Use 1.3.5 image with updated OAuth consumer version
 - 0.2.2: Change service from `NodePort` to `ClusterIP`
 - 0.2.1: Change image pullPolicy values to `IfNotPresent`

--- a/charts/tool-quickstatements/templates/deployment.yaml
+++ b/charts/tool-quickstatements/templates/deployment.yaml
@@ -20,10 +20,21 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+
+      volumes:
+      - name: extra-tls
+        secret:
+          secretName: {{ .Values.extraCert.secretName }}
+          optional: true
+
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: extra-tls
+              mountPath: /usr/share/ca-certificates/extra
+              readOnly: true
           env:
             - name: PLATFORM_MW_BACKEND_HOST
               value: {{ .Values.platform.mediawikiBackendHost | quote }}
@@ -70,6 +81,7 @@ spec:
           #     port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/tool-quickstatements/values.yaml
+++ b/charts/tool-quickstatements/values.yaml
@@ -24,6 +24,10 @@ php:
 #   sessionSaveRedisAuthSecretKey:
 #   sessionSaveRedisPrefix:
 
+# additional tls certificate source
+extraCert:
+  secretName: someTlsSecret
+
 service:
   type: ClusterIP
   port: 80

--- a/charts/wikibase-cloud-clusterissuers/Chart.yaml
+++ b/charts/wikibase-cloud-clusterissuers/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: wikibase-cloud-clusterissuers
-version: 0.2.1
+version: 0.3.0
 maintainers:
   - name: WBstack
     url: https://github.com/wbstack

--- a/charts/wikibase-cloud-clusterissuers/README.md
+++ b/charts/wikibase-cloud-clusterissuers/README.md
@@ -5,6 +5,7 @@ This chart deploys cert-manager `ClusterIssuer` resources, which represent CAs t
 https://cert-manager.io/docs/configuration/
 
 ## changelog
+- 0.3.0: Wrap resource definitions in conditional blocks, to ensure only relevant resources get deployed to the right environment
 - 0.2.1: Add self-signed CA bootstrapping (docs: https://cert-manager.io/docs/configuration/selfsigned/#bootstrapping-ca-issuers)
 - 0.2.0: Add self-signed cluster issuer for local environment
 - 0.1.0: Initial tag

--- a/charts/wikibase-cloud-clusterissuers/templates/local.yaml
+++ b/charts/wikibase-cloud-clusterissuers/templates/local.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.environment "local" }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -31,3 +32,4 @@ metadata:
 spec:
   ca:
     secretName: wikibase-local-root-secret
+{{- end }}

--- a/charts/wikibase-cloud-clusterissuers/templates/production.yaml
+++ b/charts/wikibase-cloud-clusterissuers/templates/production.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.environment "production" }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -34,4 +35,4 @@ spec:
             - {{ . | quote }}
           {{- end }}
         {{- end }}
-
+{{- end }}

--- a/charts/wikibase-cloud-clusterissuers/templates/staging.yaml
+++ b/charts/wikibase-cloud-clusterissuers/templates/staging.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.environment "staging" }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -34,3 +35,4 @@ spec:
               - {{ . | quote }}
             {{- end }}
           {{- end }}
+{{- end }}


### PR DESCRIPTION
context: https://phabricator.wikimedia.org/T383335#10591561

This adds the option to specify a k8s tls secret name that will be used to mount under /usr/share/ca-certificates/extra in the container

