### PR TITLE
querybuilder 0.2.0: extra tls chart

### DIFF
--- a/charts/tool-querybuilder/Chart.yaml
+++ b/charts/tool-querybuilder/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tool-querybuilder
 description: A Helm chart for deploying the Wikidata query builder https://gerrit.wikimedia.org/g/wikidata/query-builder
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: 1.0.0
 
 maintainers:

--- a/charts/tool-querybuilder/README.md
+++ b/charts/tool-querybuilder/README.md
@@ -1,5 +1,5 @@
 # wbstack tool-querybuilder
 
 ## Changelog
-
+- 0.2.0: Add extra tls cert volume mount
 - 0.1.0: initial chart

--- a/charts/tool-querybuilder/templates/deployment.yaml
+++ b/charts/tool-querybuilder/templates/deployment.yaml
@@ -24,12 +24,23 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+
+      volumes:
+        - name: extra-tls
+          secret:
+            secretName: {{ .Values.extraCert.secretName }}
+            optional: true
+
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: extra-tls
+              mountPath: /usr/share/ca-certificates/extra
+              readOnly: true
           env:
             - name: PLATFORM_MW_BACKEND_HOST
               value: {{ .Values.platform.mediawikiBackendHost | quote }}

--- a/charts/tool-querybuilder/values.yaml
+++ b/charts/tool-querybuilder/values.yaml
@@ -14,6 +14,10 @@ app:
   subclassPropertyMap: '{"default":"P279","P171":"P171","P131":"P131"}'
   siConversionProperty: 'P2370'
 
+# additional tls certificate source
+extraCert:
+  secretName: someTlsSecret
+
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
context: https://phabricator.wikimedia.org/T383335#10591561

This adds the option to specify a k8s tls secret name that will be used to mount under /usr/share/ca-certificates/extra in the container

