### PR TITLE
cradle 0.2.0:  extra tls chart

### DIFF
--- a/charts/tool-cradle/Chart.yaml
+++ b/charts/tool-cradle/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: tool-cradle
-version: 0.1.2
+version: 0.2.0
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/tool-cradle/README.md
+++ b/charts/tool-cradle/README.md
@@ -1,7 +1,7 @@
 # wbstack tool-cradle
 
 ## Changelog
-
+- 0.2.0: Add extra tls cert volume mount
 - 0.1.2: Change service from `NodePort` to `ClusterIP`
 - 0.1.1: Change image pullPolicy values to `IfNotPresent`
 - 0.1.0: Initial tag

--- a/charts/tool-cradle/templates/deployment.yaml
+++ b/charts/tool-cradle/templates/deployment.yaml
@@ -20,10 +20,21 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+
+      volumes:
+        - name: extra-tls
+          secret:
+            secretName: {{ .Values.extraCert.secretName }}
+            optional: true
+
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: extra-tls
+              mountPath: /usr/share/ca-certificates/extra
+              readOnly: true
           ports:
             - name: http
               containerPort: 80

--- a/charts/tool-cradle/values.yaml
+++ b/charts/tool-cradle/values.yaml
@@ -9,6 +9,10 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# additional tls certificate source
+extraCert:
+  secretName: someTlsSecret
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
context: https://phabricator.wikimedia.org/T383335#10591561

This adds the option to specify a k8s tls secret name that will be used to mount under /usr/share/ca-certificates/extra in the container

