### PR TITLE
tool-widar 0.3.0: add extra tls

### DIFF
--- a/charts/tool-widar/Chart.yaml
+++ b/charts/tool-widar/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: tool-widar
-version: "0.2.0"
+version: "0.3.0"
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/tool-widar/README.md
+++ b/charts/tool-widar/README.md
@@ -2,6 +2,7 @@
 
 ## Changelog
 
+- 0.3.0: Add extra tls cert volume mount
 - 0.1.2: Change service from `NodePort` to `ClusterIP`
 - 0.1.1: Change image pullPolicy values to `IfNotPresent`
 - 0.1.0: Initial tag

--- a/charts/tool-widar/templates/deployment.yaml
+++ b/charts/tool-widar/templates/deployment.yaml
@@ -20,10 +20,21 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+
+      volumes:
+        - name: extra-tls
+          secret:
+            secretName: {{ .Values.extraCert.secretName }}
+            optional: true
+
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: extra-tls
+              mountPath: /usr/share/ca-certificates/extra
+              readOnly: true
           env:
             - name: PLATFORM_MW_BACKEND_HOST
               value: {{ .Values.platform.mediawikiBackendHost | quote }}

--- a/charts/tool-widar/values.yaml
+++ b/charts/tool-widar/values.yaml
@@ -24,6 +24,10 @@ php:
 #   sessionSaveRedisAuthSecretKey:
 #   sessionSaveRedisPrefix:
 
+# additional tls certificate source
+extraCert:
+  secretName: someTlsSecret
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
context: https://phabricator.wikimedia.org/T383335#10591561

This adds the option to specify a k8s tls secret name that will be used to mount under /usr/share/ca-certificates/extra in the container

