### PR TITLE
quickstatements 0.3.0: add extra tls

### DIFF
--- a/charts/tool-quickstatements/Chart.yaml
+++ b/charts/tool-quickstatements/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: tool-quickstatements
-version: "0.2.3"
+version: "0.3.0"
 home: https://github.com/wbstack
 maintainers:
   - name: WBstack

--- a/charts/tool-quickstatements/README.md
+++ b/charts/tool-quickstatements/README.md
@@ -1,7 +1,7 @@
 # wbstack tool-quickstatement
 
 ## Changelog
-
+- 0.3.0: Add extra tls cert volume mount
 - 0.2.3: Use 1.3.5 image with updated OAuth consumer version
 - 0.2.2: Change service from `NodePort` to `ClusterIP`
 - 0.2.1: Change image pullPolicy values to `IfNotPresent`

--- a/charts/tool-quickstatements/templates/deployment.yaml
+++ b/charts/tool-quickstatements/templates/deployment.yaml
@@ -20,10 +20,21 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+
+      volumes:
+        - name: extra-tls
+          secret:
+            secretName: {{ .Values.extraCert.secretName }}
+            optional: true
+
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: extra-tls
+              mountPath: /usr/share/ca-certificates/extra
+              readOnly: true
           env:
             - name: PLATFORM_MW_BACKEND_HOST
               value: {{ .Values.platform.mediawikiBackendHost | quote }}

--- a/charts/tool-quickstatements/values.yaml
+++ b/charts/tool-quickstatements/values.yaml
@@ -24,6 +24,10 @@ php:
 #   sessionSaveRedisAuthSecretKey:
 #   sessionSaveRedisPrefix:
 
+# additional tls certificate source
+extraCert:
+  secretName: someTlsSecret
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
context: https://phabricator.wikimedia.org/T383335#10591561

This adds the option to specify a k8s tls secret name that will be used to mount under /usr/share/ca-certificates/extra in the container

