### PR TITLE
redirects: release new chart using rewrite-target

### DIFF
--- a/charts/redirects/Chart.yaml
+++ b/charts/redirects/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redirects
 description: Create ingresses for redirecting subdomains elsewhere
 type: application
-version: 1.0.0
+version: 2.0.0
 appVersion: "1.0.0"
 maintainers:
   - name: WBstack

--- a/charts/redirects/templates/ingresses.yaml
+++ b/charts/redirects/templates/ingresses.yaml
@@ -5,8 +5,8 @@ kind: Ingress
 metadata:
   name: redirect-ingress-{{ .host }}
   annotations:
-    nginx.ingress.kubernetes.io/server-snippet: |
-      return {{ .statusCode }} {{ .toLocation }}$request_uri;  
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: {{ .toLocation }}/$1
 spec:
   ingressClassName: nginx
   rules:

--- a/charts/redirects/values.yaml
+++ b/charts/redirects/values.yaml
@@ -1,5 +1,4 @@
 redirects:
   - host: example.com
     toLocation: https://example.net
-    statusCode: 302
     tlsName: tls-example-secret


### PR DESCRIPTION
It seems like since we updated nginx (presumably a long time ago) the previous `snippets` call became considered a `Critial` level risk and therefore was disabled[0] by default.

This broke our status page redirects. We should move to an alternative redirect solution[1]

[0] https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations-risk/
[1] https://medium.com/@megaurav25/url-redirection-with-full-url-path-preservation-using-ingress-nginx-493f18523c99

Bug: T390071