### PR TITLE
cloud-clusterissuers v0.3.1: fix conditional blocks

### DIFF
--- a/charts/wikibase-cloud-clusterissuers/Chart.yaml
+++ b/charts/wikibase-cloud-clusterissuers/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: wikibase-cloud-clusterissuers
-version: 0.3.0
+version: 0.3.1
 maintainers:
   - name: WBstack
     url: https://github.com/wbstack

--- a/charts/wikibase-cloud-clusterissuers/README.md
+++ b/charts/wikibase-cloud-clusterissuers/README.md
@@ -5,6 +5,7 @@ This chart deploys cert-manager `ClusterIssuer` resources, which represent CAs t
 https://cert-manager.io/docs/configuration/
 
 ## changelog
+- 0.3.1: Fix previous conditions, since there was a confusion about Let's Encrypts staging & produciton and our staging environments
 - 0.3.0: Wrap resource definitions in conditional blocks, to ensure only relevant resources get deployed to the right environment
 - 0.2.1: Add self-signed CA bootstrapping (docs: https://cert-manager.io/docs/configuration/selfsigned/#bootstrapping-ca-issuers)
 - 0.2.0: Add self-signed cluster issuer for local environment

--- a/charts/wikibase-cloud-clusterissuers/templates/production.yaml
+++ b/charts/wikibase-cloud-clusterissuers/templates/production.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.environment "production" }}
+{{- if ne .Values.environment "local" }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/charts/wikibase-cloud-clusterissuers/templates/staging.yaml
+++ b/charts/wikibase-cloud-clusterissuers/templates/staging.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.environment "staging" }}
+{{- if ne .Values.environment "local" }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:


### PR DESCRIPTION
In v0.3.0 https://github.com/wbstack/charts/pull/187
we added conditional statements for "staging & production" cluster issuers.

What we thought those meant: the cluster issuers for our staging and production environments
What it turned out to be: the Let's Encrypt staging and production environments: https://letsencrypt.org/docs/staging-environment/

So with this version those two get used again for both environments, but not on local.

