### PR TITLE
argocd-config 2.1.1: temp re-add bitnami repoURL

### DIFF
--- a/charts/argocd-config/Chart.yaml
+++ b/charts/argocd-config/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-config
 description: Chart to deploy ArgoCD configuration (including the argocd-apps chart)
 type: application
-version: 2.1.0
+version: 2.1.1
 appVersion: "1.0"
 maintainers:
   - name: WBstack

--- a/charts/argocd-config/README.md
+++ b/charts/argocd-config/README.md
@@ -3,6 +3,9 @@
 Configures permissions Argo CD and deploys the "app-of-apps" (see ../argocd-apps/README.md)
 
 ## Changelog
+## 2.1.1
+- re-add bitnami chart repo URL temporarily, so redis can get removed
+
 ## 2.1.0
 - remove redis deployments
 

--- a/charts/argocd-config/templates/projects.yaml
+++ b/charts/argocd-config/templates/projects.yaml
@@ -17,6 +17,7 @@ spec:
   sourceRepos:
   - {{ .Values.repoUrls.deploy }}
   - {{ .Values.repoUrls.wbstack }}
+  - {{ .Values.repoUrls.bitnami }}
   clusterResourceWhitelist:
   - group: rbac.authorization.k8s.io
     kind: ClusterRole


### PR DESCRIPTION
https://phabricator.wikimedia.org/T405468

To let argo remove the redis deployments it still needs the repoURL, so we re-add it here temporearily and then remove it again.

